### PR TITLE
feat(rclone-config): Adding --size-only to rclone config that can speed up transfers

### DIFF
--- a/storage/caios-to-dfs/copy.sh
+++ b/storage/caios-to-dfs/copy.sh
@@ -7,6 +7,7 @@ SHARD=$(printf "shard_%02d" ${SLURM_PROCID})
     copy caios:<BUCKET_NAME> <DESTINATION_PATH> \
     --files-from=<WORK_DIR>/shards/${SHARD} \
     --ignore-existing \
+    --size-only \
     --fast-list \
     --transfers=128 \
     --checkers=256 \


### PR DESCRIPTION
Adding `--size-only` to the rclone config in the sample scripts for copying data from CAIOS to DFS, which can speed up 

https://rclone.org/docs/#size-only

<img width="1431" height="137" alt="image" src="https://github.com/user-attachments/assets/0b0ca9d6-8d92-41b1-9f71-804a50bedd27" />
