### PR TITLE
feat(zot-oci-registry-in-cluster): add zot in-cluster OCI registry Helm chart with LOTA benchmark reports

### DIFF
--- a/zot-oci-registry-in-cluster/.helmignore
+++ b/zot-oci-registry-in-cluster/.helmignore
@@ -1,0 +1,2 @@
+reports/
+files/

--- a/zot-oci-registry-in-cluster/Chart.yaml
+++ b/zot-oci-registry-in-cluster/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: zot-infra
+description: >
+  Bootstraps the infrastructure layer for a Zot OCI registry on Kubernetes:
+  internal CA (cert-manager Certificate + ClusterIssuer), internal Gateway
+  (GatewayParameters, IP-SAN certificate, Gateway, HTTPRoute), external Gateway
+  (GatewayParameters, Let's Encrypt Gateway, HTTPRoute), and the containerd
+  DaemonSet that distributes the CA cert and hosts.toml to every node.
+  Upstream Helm charts (kgateway, cert-manager, zot) are managed separately.
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/zot-oci-registry-in-cluster/README.md
+++ b/zot-oci-registry-in-cluster/README.md
@@ -1,0 +1,438 @@
+# Zot OCI Registry — Deployment Guide
+
+## Overview
+
+This guide covers deploying [Zot](https://zotregistry.dev) as an internal OCI registry on Kubernetes with TLS termination via kgateway (Gateway API). Two access paths are documented:
+
+- **External** — TLS via a publicly accessible hostname (Let's Encrypt), used for pushing images and accessing the Web UI
+- **Internal** — TLS via a private CA, accessed directly by containerd within the cluster via a internal-lb cidr LoadBalancer IP
+
+## Prerequisites
+
+- kgateway v2.2.2+ installed (see [Dependencies](#dependencies))
+- cert-manager installed with the following `ClusterIssuers` available (see [Dependencies](#dependencies)):
+  - `letsencrypt-prod` — for external TLS
+  - `selfsigned-cluster-issuer` — used to bootstrap the internal CA
+  - `internal-ca-issuer` — for internal TLS (see [Internal CA Bootstrap](#internal-ca-bootstrap))
+- Choose an unused VIP from the internal_lb CIDR pool
+- Helm 3.x
+- `kubectl` configured against the target cluster
+- `cwic` Coreweave CLI
+
+---
+
+## Dependencies
+
+### kgateway
+
+Installs the Gateway API CRDs (standard channel) and the kgateway controller.
+
+```bash
+# Gateway API CRDs (standard channel)
+kubectl apply -f \
+  https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/standard-install.yaml
+
+# kgateway CRDs
+helm upgrade -i kgateway-crds \
+  oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds \
+  --create-namespace \
+  --namespace kgateway-system \
+  --version v2.2.2
+
+# kgateway controller
+helm upgrade -i kgateway \
+  oci://cr.kgateway.dev/kgateway-dev/charts/kgateway \
+  --namespace kgateway-system \
+  --version v2.2.2
+```
+
+### cert-manager
+
+Install cert-manager using the CoreWeave Helm chart with cluster issuers pre-configured. The values file enables `letsencrypt-prod`, `letsencrypt-staging`, and `selfsigned-cluster-issuer` with Gateway API HTTP-01 challenge support.
+
+```bash
+helm repo add coreweave https://charts.core-services.ingress.coreweave.com
+
+helm repo update
+
+# Initial install without values
+helm -n kube-system upgrade --install cert-manager coreweave/cert-manager
+
+# Apply with cluster issuer values
+helm -n kube-system upgrade --install cert-manager coreweave/cert-manager \
+  -f files/cert-manager-values.yaml
+```
+
+### Verify
+
+```bash
+kubectl get clusterissuer
+NAME                        READY   AGE
+letsencrypt-prod            True    165m
+letsencrypt-staging         True    165m
+selfsigned-cluster-issuer   True    165m
+
+kubectl get pods -n kgateway-system
+NAME                                    READY   STATUS    RESTARTS   AGE
+kgateway-54c457cc5c-bfwx9               1/1     Running   0          168m
+
+kubectl get gatewayclass
+NAME       CONTROLLER              ACCEPTED   AGE
+kgateway   kgateway.dev/kgateway   True       169m
+```
+
+---
+
+## Zot Helm Install
+
+Generate htpasswd credentials before installing:
+
+```bash
+# Install htpasswd if needed: apt install apache2-utils
+htpasswd -nbB <ZOT_USERNAME> <ZOT_PASSWORD>
+# Copy the output — this is <ZOT_HTPASSWD_STRING>
+```
+
+```bash
+helm repo add zotregistry https://zotregistry.dev/helm-charts
+helm repo update
+
+helm -n zot-registry upgrade --install zot zotregistry/zot \
+  --version 0.1.98 \
+  --create-namespace \
+  -f files/zot-values.yaml
+```
+
+### Placeholders (`files/zot-values.yaml`)
+
+| Placeholder | Description |
+|---|---|
+| `<ZOT_USERNAME>` | Registry admin username — set in `accessControl.adminPolicy.users` |
+| `<ZOT_HTPASSWD_STRING>` | Output of `htpasswd -nbB <ZOT_USERNAME> <ZOT_PASSWORD>` — set in `secretFiles.htpasswd` |
+| `<S3_REGION>` | Object storage bucket region (e.g. `us-east-14a`) |
+| `<S3_BUCKET_NAME>` | AI Object Storage bucket name |
+| `<S3_ACCESS_KEY_ID>` | Object storage access key ID |
+| `<S3_SECRET_KEY>` | Object storage secret key |
+
+---
+
+## zot-infra Infrastructure Chart
+
+The internal CA, both Gateways, and the containerd DaemonSet are all managed by the `zot-infra` Helm chart. Fill in `zot-infra/values.yaml` with the values described in each section below, then install once:
+
+```bash
+helm -n zot-registry upgrade -i zot-infra ./zot-infra \
+  -f ./zot-infra/values.yaml
+```
+
+---
+
+## Internal CA Bootstrap
+
+Creates a self-signed CA and a `ClusterIssuer` backed by it. All internal leaf certs are signed by this CA. cert-manager will automatically retry issuance of the internal leaf certificate once the `ClusterIssuer` reaches `READY=True` — no separate install step is needed.
+
+### Values (`zot-infra/values.yaml`)
+
+| Key | Description |
+|---|---|
+| `ca.certificateName` | Name of the cert-manager Certificate resource for the CA |
+| `ca.secretName` | Secret where the CA key/cert are stored — referenced by the ClusterIssuer and DaemonSet |
+| `ca.issuerName` | Name of the ClusterIssuer backed by this CA |
+| `ca.bootstrapIssuer` | Pre-existing ClusterIssuer used to self-sign the CA (must already exist) |
+| `namespaces.certManager` | Namespace where cert-manager is installed (default: `kube-system`) |
+
+### Verify
+
+```bash
+# Wait for READY=True before proceeding
+kubectl get clusterissuer internal-ca-issuer
+NAME                 READY   AGE
+internal-ca-issuer   True    145m
+```
+
+---
+
+## External Gateway (Let's Encrypt TLS)
+
+Exposes zot on a public hostname with TLS terminated at the Gateway using a Let's Encrypt certificate managed by cert-manager. This endpoint is used for:
+
+- **Pushing images** from external CI/CD pipelines or developer machines via `docker push` / `skopeo copy`
+- **Accessing the Zot Web UI** at `https://registry.<ORG_ID-CLUSTER_NAME>.coreweave.app`
+
+### Values (`zot-infra/values.yaml`)
+
+| Key | Description |
+|---|---|
+| `externalGateway.clusterOrgHostname` | ORG ID and CKS Cluster Name (e.g. `cwxxx-cluster03`) |
+| `namespaces.kgateway` | Namespace where kgateway is installed (default: `kgateway-system`) |
+| `namespaces.zot` | Namespace where zot is installed (default: `zot-registry`) |
+
+### Verify
+
+```bash
+kubectl get gateway zot-external-gateway -n kgateway-system
+NAME                   CLASS      ADDRESS         PROGRAMMED   AGE
+zot-external-gateway   kgateway   166.xx.xx.xx   True         106m
+
+kubectl get certificate -n kgateway-system
+NAME                     READY   SECRET                     AGE
+zot-public-cert-secret   True    zot-public-cert-secret     106m
+
+kubectl get httproute -n zot-registry
+NAME                 HOSTNAMES                                          AGE
+zot-external-route   ["registry.ORG_ID-CLUSTER_NAME.coreweave.app"]   106m
+```
+
+### Push an image via the external endpoint
+
+```bash
+# Log in
+docker login registry.<ORG_ID-CLUSTER_NAME>.coreweave.app \
+  -u <ZOT_USERNAME> -p <ZOT_PASSWORD>
+
+# Tag and push
+docker tag myapp:latest \
+  registry.<ORG_ID-CLUSTER_NAME>.coreweave.app/myapp:latest
+
+docker push registry.<ORG_ID-CLUSTER_NAME>.coreweave.app/myapp:latest
+```
+
+### Web UI
+
+Navigate to `https://registry.<ORG_ID-CLUSTER_NAME>.coreweave.app` in a browser to browse repositories, tags, and image details via the Zot UI.
+
+---
+
+## Internal Gateway (Private CA TLS + internal-lb VIP)
+
+Exposes zot on a fixed internal LoadBalancer IP for direct in-cluster pulls by containerd. TLS is terminated at the Gateway using a cert with an IP SAN matching the internal-lb IP.
+
+### Values (`zot-infra/values.yaml`)
+
+| Key | Description |
+|---|---|
+| `internalGateway.lbIP` | Fixed internal-lb IP for the LoadBalancer Service (e.g. `10.16.12.10`) |
+| `namespaces.kgateway` | Namespace where kgateway is installed (default: `kgateway-system`) |
+| `namespaces.zot` | Namespace where zot is installed (default: `zot-registry`) |
+
+### Verify
+
+```bash
+kubectl get gateway zot-internal-gateway -n kgateway-system
+NAME                   CLASS      ADDRESS       PROGRAMMED   AGE
+zot-internal-gateway   kgateway   10.16.12.10   True         85m
+
+kubectl get certificate -n kgateway-system
+NAME                     READY   SECRET                     AGE
+zot-internal-cert        True    zot-internal-cert-secret   85m
+zot-public-cert-secret   True    zot-public-cert-secret     104m
+
+kubectl get svc zot-internal-gateway -n kgateway-system
+NAME                   TYPE           CLUSTER-IP   EXTERNAL-IP   PORT(S)          AGE
+zot-internal-gateway   LoadBalancer   10.16.8.79   10.16.12.10   5000:31997/TCP   86m
+```
+
+---
+
+## containerd DaemonSet (Node TLS Config)
+
+Writes the internal CA cert and `hosts.toml` to every node so containerd can pull images from the internal registry over TLS without a restart. The CA cert is sourced directly from the secret named by `ca.secretName` — no manual cert distribution needed.
+
+### Values (`zot-infra/values.yaml`)
+
+| Key | Description |
+|---|---|
+| `internalGateway.lbIP` | Must match the internal Gateway LB IP |
+| `ca.secretName` | Name of the secret holding the CA cert — mounted into the DaemonSet init container |
+| `namespaces.certManager` | Namespace where the DaemonSet is created (default: `kube-system`) |
+
+### Verify
+
+```bash
+kubectl -n kube-system get ds zot-internal-containerd-ds
+NAME                         DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
+zot-internal-containerd-ds   1         1         1       1            1           <none>          81m
+
+# Confirm files written on a node
+cwic node shell WORKER_NODE_ID
+
+ls /etc/containerd/certs.d/
+10.16.12.10:5000
+
+ls /etc/containerd/certs.d/10.16.12.10\:5000/
+ca.crt  hosts.toml
+```
+
+### CA rotation
+
+```bash
+kubectl -n kube-system rollout restart ds/zot-internal-containerd-ds
+```
+
+---
+
+## imagePullSecret
+
+For workloads pulling from the internal registry, create an `imagePullSecret` in each namespace:
+
+```bash
+kubectl create secret docker-registry zot-pull-secret \
+  --docker-server=<INTERNAL_LB_IP>:5000 \
+  --docker-username=<ZOT_USERNAME> \
+  --docker-password=<ZOT_PASSWORD> \
+  -n <WORKLOAD_NAMESPACE>
+```
+
+Reference in pod specs:
+
+```yaml
+imagePullSecrets:
+  - name: zot-pull-secret
+```
+
+---
+
+## Example: Mirroring Images from ECR to Zot
+
+Use a Kubernetes Job with `skopeo` to copy images from Amazon ECR into the Zot registry. The Job mounts the internal CA cert from the `<INTERNAL_CA_SECRET_NAME>` secret so skopeo can verify the Zot TLS endpoint.
+
+ECR tokens expire every 12 hours. Retrieve a fresh token before running the Job:
+
+```bash
+export ECR_TOKEN=$(aws ecr get-login-password --region <AWS_REGION>)
+```
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: skopeo-mirror-ecr
+  namespace: kube-system
+spec:
+  ttlSecondsAfterFinished: 3600
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: skopeo
+          image: quay.io/skopeo/stable:latest
+          command:
+            - skopeo
+            - copy
+            - --multi-arch=all
+            - --src-creds=AWS:${ECR_TOKEN}
+            - --dest-creds=<ZOT_USERNAME>:<ZOT_PASSWORD>
+            - --dest-cert-dir=/etc/zot-ca
+            - --dest-tls-verify=true
+            - docker://<AWS_ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/<ECR_IMAGE>:<TAG>
+            - docker://<INTERNAL_LB_IP>:5000/<ECR_IMAGE>:<TAG>
+          volumeMounts:
+            - name: zot-ca
+              mountPath: /etc/zot-ca
+              readOnly: true
+      volumes:
+        - name: zot-ca
+          secret:
+            secretName: <INTERNAL_CA_SECRET_NAME>
+            items:
+              - key: ca.crt
+                path: ca.crt
+EOF
+```
+
+```bash
+kubectl apply -f - <<'EOF'
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: skopeo-mirror-pytorch
+  namespace: kube-system
+spec:
+  ttlSecondsAfterFinished: 3600
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: skopeo
+          image: quay.io/skopeo/stable:latest
+          command:
+            - skopeo
+            - copy
+            - --override-arch=amd64
+            - --override-os=linux
+            - --dest-creds=admin:$(ZOT_PASSWORD)
+            - --dest-cert-dir=/ca
+            - --dest-tls-verify=true
+            - docker://docker.io/pytorch/pytorch:2.11.0-cuda12.8-cudnn9-devel
+            - docker://10.16.12.10:5000/pytorch/pytorch:2.11.0-cuda12.8-cudnn9-devel
+          env:
+            - name: ZOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: zot-credentials
+                  key: password
+          volumeMounts:
+            - name: ca-secret
+              mountPath: /ca
+              readOnly: true
+      volumes:
+        - name: ca-secret
+          secret:
+            secretName: zot-infra-ca-secret
+            items:
+              - key: ca.crt
+                path: ca.crt
+EOF
+```
+
+```bash
+# Watch progress
+kubectl logs -n kube-system -l job-name=skopeo-mirror-ecr -f
+
+# Verify image landed in zot
+curl -u <ZOT_USERNAME>:<ZOT_PASSWORD> \
+  https://<INTERNAL_LB_IP>:5000/v2/<ECR_IMAGE>/tags/list \
+  --cacert <(kubectl get secret <INTERNAL_CA_SECRET_NAME> -n kube-system \
+    -o jsonpath='{.data.ca\.crt}' | base64 -d)
+```
+
+### Placeholders
+
+| Placeholder | Description |
+|---|---|
+| `<AWS_REGION>` | AWS region of the ECR registry (e.g. `us-east-1`) |
+| `<AWS_ACCOUNT_ID>` | AWS account ID |
+| `<ECR_IMAGE>` | ECR repository and image name (e.g. `myorg/myapp`) |
+| `<TAG>` | Image tag to mirror (e.g. `v1.0.0`) |
+| `<ZOT_USERNAME>` / `<ZOT_PASSWORD>` | Zot registry credentials |
+| `<INTERNAL_LB_IP>` | Internal MetalLB LB IP |
+| `<INTERNAL_CA_SECRET_NAME>` | CA secret name (e.g. `internal-ca-secret`) |
+
+---
+
+## Benchmarks & Reports
+
+Performance analysis and test artifacts are available under `zot-infra/reports/`:
+
+| File | Description |
+|---|---|
+| [`zb-benchmark.md`](zot-infra/reports/zb-benchmark.md) | Analysis of zot registry throughput and latency with and without LOTA as the storage backend, covering push, pull, and mixed workloads across 1MB / 10MB / 100MB object sizes |
+| [`enroot.md`](zot-infra/reports/enroot.md) | Analysis of `enroot import` performance against the zot registry with and without LOTA, including cold/warm cache behavior and the SLURM multi-user caching scenario |
+| [`zb-bencharmarking.yaml`](zot-infra/reports/zb-bencharmarking.yaml) | Kubernetes Job manifest used to run the `zb` benchmark tool against the registry |
+| [`zb-benchmark-with-lota.txt`](zot-infra/reports/zb-benchmark-with-lota.txt) | Raw `zb` output — zot backed by LOTA (`cwlota.com`) |
+| [`zb-benchmark-without-lota.txt`](zot-infra/reports/zb-benchmark-without-lota.txt) | Raw `zb` output — zot backed by CAIOS directly (`cwobject.com`) |
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---|---|---|
+| `x509: certificate signed by unknown authority` | CA cert not on node yet | Wait for DS pod to complete or check DS logs |
+| `authorization failed: no basic auth credentials` | Pull secret server address mismatch | Recreate pull secret with exact registry address |
+| `LoadBalancer Ingress` shows wrong IP | internal-lb cidr not honoring annotation | Verify IP is in an `IPAddressPool` range |
+| `certificate not ready` | cert-manager cannot issue cert | Check `kubectl describe certificate` for events |
+| Gateway `PROGRAMMED: False` | GatewayParameters or cert secret missing | Check `kubectl describe gateway` for conditions |
+| `received unexpected HTTP status: 500` | skopeo using HTTP instead of HTTPS | Add `--dest-tls-verify=true` to skopeo command |
+| `Invalid destination name docker://https://` | Incorrect skopeo destination format | Use `docker://IP:PORT` without `https://` prefix |

--- a/zot-oci-registry-in-cluster/files/cert-manager-values.yaml
+++ b/zot-oci-registry-in-cluster/files/cert-manager-values.yaml
@@ -1,0 +1,49 @@
+cert-issuers:
+  enabled: true
+  clusterIssuers:
+    - name: letsencrypt-prod
+      annotations: {}
+      labels: {}
+      spec:
+        acme:
+          server: https://acme-v02.api.letsencrypt.org/directory
+          privateKeySecretRef:
+            name: letsencrypt-prod-account-key
+          solvers:
+            - http01:
+                gatewayHTTPRoute:
+                  parentRefs:
+                    - name: zot-external-gateway
+                      namespace: kgateway-system
+                      kind: Gateway
+    - name: letsencrypt-staging
+      annotations: {}
+      labels: {}
+      spec:
+        acme:
+          server: https://acme-staging-v02.api.letsencrypt.org/directory
+          privateKeySecretRef:
+            name: letsencrypt-staging-account-key
+          solvers:
+            - http01:
+                gatewayHTTPRoute:
+                  parentRefs:
+                    - name: zot-external-gateway
+                      namespace: kgateway-system
+                      kind: Gateway
+    - name: selfsigned-cluster-issuer
+      spec:
+        selfSigned: {}
+  issuers: []
+cert-manager:
+  global:
+    podSecurityPolicy:
+      enabled: false
+  crds:
+    enabled: true
+    keep: true
+  config:
+    apiVersion: controller.config.cert-manager.io/v1alpha1
+    kind: ControllerConfiguration
+    enableGatewayAPI: true
+    

--- a/zot-oci-registry-in-cluster/files/values-test.yaml
+++ b/zot-oci-registry-in-cluster/files/values-test.yaml
@@ -1,0 +1,30 @@
+namespaces:
+  certManager: kube-system
+  kgateway: kgateway-system
+  zot: zot-registry
+
+ca:
+  bootstrapIssuer: selfsigned-cluster-issuer
+  duration: 87600h
+  renewBefore: 720h
+
+internalGateway:
+  lbIP: "10.16.12.10"
+  port: 5000
+  zotServiceName: zot
+  duration: 8760h
+  renewBefore: 720h
+
+externalGateway:
+  clusterOrgHostname: cwxx-xx-cluster04
+  clusterIssuer: letsencrypt-prod
+  zotServiceName: zot
+  port: 5000
+  networkPolicy:
+    enabled: true
+    allowedCIDRs:
+      - cidr: 74.96.xx.xx/32
+
+daemonset:
+  initImage: busybox:1.36
+  pauseImage: registry.k8s.io/pause:3.10

--- a/zot-oci-registry-in-cluster/files/zot-values.yaml
+++ b/zot-oci-registry-in-cluster/files/zot-values.yaml
@@ -1,0 +1,103 @@
+replicaCount: 1
+
+strategy:
+  type: Recreate
+
+serviceAccount:
+  create: true
+
+service:
+  type: ClusterIP
+  port: 5000
+
+persistence: false
+
+# Startup probe: allows up to 180s (initialDelaySeconds) + 30 * 10s = 5 min
+# for zot to connect to S3 and finish initializing before liveness/readiness
+# probes begin. /startupz returns 200 once zot is ready to serve. Adjust if there are lots of stored images
+startupProbe:
+  httpGet:
+    path: /startupz
+    port: 5000
+    scheme: HTTP
+  initialDelaySeconds: 180  # Allow zot to meta parse/sync with S3 before starting probes
+  periodSeconds: 10
+  failureThreshold: 30      # 180s + 30*10s = up to 7 min total
+  successThreshold: 1
+  timeoutSeconds: 5
+
+# Liveness probe: restarts pod if zot is deadlocked or unresponsive.
+# /livez is a lightweight endpoint — does not check storage or S3.
+livenessProbe:
+  httpGet:
+    path: /livez
+    port: 5000
+    scheme: HTTP
+  periodSeconds: 30
+  failureThreshold: 3       # restart after 3 * 30s = 90s of failures
+  successThreshold: 1
+  timeoutSeconds: 5
+
+# Readiness probe: removes pod from service endpoints if zot cannot serve
+# requests. /readyz checks that the HTTP server is fully operational.
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: 5000
+    scheme: HTTP
+  initialDelaySeconds: 5
+  periodSeconds: 15
+  failureThreshold: 3
+  successThreshold: 1
+  timeoutSeconds: 5
+
+mountConfig: true
+configFiles:
+  config.json: |
+    {
+      "storage": {
+        "rootDirectory": "/tmp/zot",
+        "dedupe": false,
+        "storageDriver": {
+          "name": "s3",
+          "rootdirectory": "/zot",
+          "region": "YOUR_REGION",
+          "bucket": "YOUR_BUCKET_NAME",
+          "regionendpoint": "http://cwlota.com",
+          "accesskey": "YOUR_ACCESS_KEY_ID",
+          "secretkey": "YOUR_SECRET_KEY",
+          "forcepathstyle": false,
+          "secure": false,
+          "skipverify": false
+        }
+      },
+      "http": {
+        "address": "0.0.0.0",
+        "port": "5000",
+        "compat": ["docker2s2"],
+        "auth": {
+          "htpasswd": {
+            "path": "/secret/htpasswd"
+          }
+        },
+        "accessControl": {
+          "adminPolicy": {
+            "users": ["YOUR_USERNAME"],
+            "actions": ["read", "create", "update", "delete"]
+          }
+        }
+      },
+      "log": { "level": "info" },
+      "extensions": {
+        "search": {
+          "enable": true
+        },
+        "ui": {
+          "enable": true
+        }
+      }
+    }
+
+mountSecret: true
+secretFiles:
+  htpasswd: ZOT_HTPASSWD_STRING

--- a/zot-oci-registry-in-cluster/reports/enroot.md
+++ b/zot-oci-registry-in-cluster/reports/enroot.md
@@ -1,0 +1,130 @@
+# Enroot Import Benchmark Report: With LOTA vs. Without LOTA
+
+## What is Enroot?
+
+[Enroot](https://github.com/NVIDIA/enroot) is NVIDIA's lightweight, unprivileged container engine designed for HPC and GPU workloads. It converts OCI/Docker images into **SquashFS** (`.sqsh`) filesystem images — a single compressed, read-only file that can be mounted at container startup without root privileges.
+
+Enroot is the standard container runtime on CoreWeave GPU nodes and integrates with SLURM via the [Pyxis](https://github.com/NVIDIA/pyxis) plugin for multi-node MPI and GPU jobs.
+
+### How `enroot import docker://` Works
+
+1. Queries the registry for the image manifest
+2. Downloads any missing OCI layers (checks local cache first)
+3. Extracts and merges the layers into a flat filesystem
+4. Converts whiteout files (layer deletions)
+5. Compresses the result into a `.sqsh` SquashFS image using `mksquashfs` (parallel, using all available CPU cores)
+
+### Enroot Local Layer Cache
+
+Enroot caches downloaded OCI layers locally under `$HOME/.cache/enroot/`, keyed by layer digest. On subsequent imports of the same image, enroot detects the cached layers (`[INFO] Found all layers in cache`) and **skips the download entirely** — it goes straight to extraction and squashfs creation. This cache is **per-user, per-node** and operates independently of LOTA's node-local cache.
+
+---
+
+## Test Details
+
+| Parameter | Value |
+|---|---|
+| Image | `pytorch/pytorch:2.11.0-cuda12.8-cudnn9-devel` |
+| Registry | `https://10.16.12.10:5000` (zot in-cluster OCI registry) |
+| Layers | 10 |
+| Output size | ~19 GB (squashfs, lzo compressed) |
+| mksquashfs parallelism | 96 processors |
+| Uncompressed size | ~22.7 GB |
+| Compression ratio | 82.28% of uncompressed |
+
+### Command
+
+The same command was used for all four runs. Credentials have been redacted:
+
+```bash
+time enroot import docker://<ZOT_USERNAME>:<ZOT_PASSWORD>@10.16.12.10:5000#pytorch/pytorch:2.11.0-cuda12.8-cudnn9-devel
+```
+
+The `#` delimiter separates the registry address from the image path — enroot's syntax for specifying a private registry. `time` was prepended to capture wall-clock, user, and sys duration for each run.
+
+---
+
+## Results
+
+### Time Breakdown per Phase (approximate)
+
+| Phase | Cold run | Warm run (enroot cache hit) |
+|---|---|---|
+| Layer download | ~35s | 0s (skipped) |
+| Layer extraction | ~26–27s | ~26–27s |
+| Whiteout conversion | ~1s | ~1s |
+| mksquashfs | ~44–49s | ~44–46s |
+
+### Wall-Clock Time Comparison
+
+| Run | Configuration | real | user | sys | Download |
+|---|---|---|---|---|---|
+| 1st (cold) | Without LOTA | **1m 47.8s** | 4m 35.7s | 4m 14.3s | 10 layers (~35s) |
+| 2nd (warm) | Without LOTA | **1m 13.3s** | 2m 04.5s | 2m 11.4s | None (local cache) |
+| 1st (cold) | With LOTA | **1m 51.5s** | 4m 37.9s | 4m 26.1s | 10 layers (~35s) |
+| 2nd (warm) | With LOTA | **1m 13.5s** | 2m 04.2s | 2m 41.3s | None (local cache) |
+
+---
+
+## Analysis
+
+### Cold Run (First Import — No Caches Warm)
+
+- **Without LOTA:** 1m 47.8s
+- **With LOTA:** 1m 51.5s — **+3.7s slower**
+
+The cold run behavior mirrors the `zb` benchmark findings: on first access, LOTA's cache is empty and every layer request proxies through LOTA to CAIOS, adding an extra network hop. For a 19 GB image across 10 layers, this overhead is only ~3.7 seconds — a negligible ~3.4% difference. The bulk of both runs is dominated by CPU-bound work (squashfs compression), not download time.
+
+### Warm Run (Second Import — Enroot Local Cache Hit)
+
+- **Without LOTA:** 1m 13.3s
+- **With LOTA:** 1m 13.5s — **~0.2s difference (effectively identical)**
+
+On the second run, enroot's local layer cache (`~/.cache/enroot/`) eliminates the download entirely for both configurations — neither LOTA nor the registry is consulted. The remaining time (~73s) is entirely CPU-bound: layer extraction, whiteout processing, and parallel mksquashfs across 96 cores.
+
+This means **LOTA's caching does not benefit the second enroot import on the same node** — enroot's own local cache takes precedence and is faster than any network fetch, regardless of whether LOTA has a warm cache or not.
+
+### The Two Cache Layers
+
+Understanding the interaction between the two caching systems is key:
+
+| Cache | Scope | Benefit |
+|---|---|---|
+| **Enroot local cache** (`~/.cache/enroot/`) | Per-user, per-node | Eliminates download entirely on repeat imports by the same user on the same node |
+| **LOTA cache** (DaemonSet, per-node) | Per-node | Accelerates pulls from CAIOS for any user on the same node whose enroot cache is cold |
+
+LOTA runs as a **DaemonSet** — one instance per node — so its cache is node-local, not cluster-wide. A warm LOTA cache on Node A does not benefit Node B. However, within the same node, LOTA's value is clear in multi-user or multi-job scenarios.
+
+#### SLURM Multi-User Scenario
+
+In SLURM environments, each user has their own `$HOME`, so enroot's layer cache at `$HOME/.cache/enroot/` is **completely separate per user**. This means every distinct SLURM user that pulls the same image on the same node will have a cold enroot cache and will contact the registry again — even if another user on that node already pulled the exact same image minutes earlier.
+
+This is where LOTA's node-local DaemonSet cache provides direct value:
+
+| Step | Without LOTA | With LOTA |
+|---|---|---|
+| User A pulls image (node cold) | enroot cold → CAIOS (~35s download) | enroot cold → LOTA cold → CAIOS (~35s + proxy overhead) |
+| User B pulls same image, same node | enroot cold → CAIOS (~35s download) | enroot cold → **LOTA warm** → served from node-local cache |
+| User A pulls same image again | **enroot warm** → 0s download | **enroot warm** → 0s download |
+
+Without LOTA, every unique SLURM user pays the full CAIOS download cost for their first pull. With LOTA, only the first user on each node incurs that cost — all subsequent users on that node hit LOTA's warm cache instead.
+
+### sys Time on Warm LOTA Run
+
+The warm LOTA run shows elevated `sys` time (2m 41.3s vs 2m 11.4s without LOTA). This is likely a squashfs I/O scheduling artifact rather than a LOTA-specific issue, as the network download phase was skipped entirely.
+
+---
+
+## Summary
+
+| Scenario | Without LOTA | With LOTA | Delta |
+|---|---|---|---|
+| Cold import (first pull, no caches) | 1m 47.8s | 1m 51.5s | +3.7s (+3.4%) |
+| Warm import (enroot local cache hit) | 1m 13.3s | 1m 13.5s | ~equal |
+
+### Key Takeaways
+
+1. **Cold import overhead with LOTA is minimal (~3.7s)** for a 19 GB, 10-layer image. The dominant cost is CPU-bound squashfs compression, not the download.
+2. **Warm runs are identical** regardless of LOTA, because enroot's local layer cache (`~/.cache/enroot/`) takes precedence — the registry is never contacted.
+3. **LOTA is a per-node DaemonSet, not a cluster-wide cache.** A warm LOTA cache on one node does not benefit other nodes. Its value is scoped to the node it runs on.
+4. **LOTA's enroot benefit is within-node, cross-user/cross-job:** the most practical use case is when a second user or SLURM job (different UID, different `$HOME`) imports the same image on the same node. Their enroot cache is cold, but LOTA's node-local cache is warm — serving layers locally instead of fetching from CAIOS again.

--- a/zot-oci-registry-in-cluster/reports/enroot.md
+++ b/zot-oci-registry-in-cluster/reports/enroot.md
@@ -1,4 +1,4 @@
-# Enroot Import Benchmark Report: With LOTA vs. Without LOTA
+# Enroot Import Benchmark Report: DockerHub vs. Zot (With and Without LOTA)
 
 ## What is Enroot?
 
@@ -18,6 +18,14 @@ Enroot is the standard container runtime on CoreWeave GPU nodes and integrates w
 
 Enroot caches downloaded OCI layers locally under `$HOME/.cache/enroot/`, keyed by layer digest. On subsequent imports of the same image, enroot detects the cached layers (`[INFO] Found all layers in cache`) and **skips the download entirely** — it goes straight to extraction and squashfs creation. This cache is **per-user, per-node** and operates independently of LOTA's node-local cache.
 
+### SquashFS Output and NFS Shared Storage
+
+The `.sqsh` file produced by `enroot import` is written to the current working directory. In SLURM environments this is typically an **NFS-mounted shared folder** accessible across all compute nodes and login nodes. This means:
+
+- Once any user imports an image and the `.sqsh` lands on NFS, **all other users and nodes can use that same file directly** — no re-import needed
+- `enroot create` and `enroot start` reference the `.sqsh` by path; if the file already exists on NFS, importing again is redundant
+- The per-user enroot layer cache (`$HOME/.cache/enroot/`) and LOTA's node-local cache are both bypassed entirely when reusing a shared `.sqsh`
+
 ---
 
 ## Test Details
@@ -25,17 +33,20 @@ Enroot caches downloaded OCI layers locally under `$HOME/.cache/enroot/`, keyed 
 | Parameter | Value |
 |---|---|
 | Image | `pytorch/pytorch:2.11.0-cuda12.8-cudnn9-devel` |
-| Registry | `https://10.16.12.10:5000` (zot in-cluster OCI registry) |
 | Layers | 10 |
 | Output size | ~19 GB (squashfs, lzo compressed) |
 | mksquashfs parallelism | 96 processors |
 | Uncompressed size | ~22.7 GB |
 | Compression ratio | 82.28% of uncompressed |
 
-### Command
+### Commands
 
-The same command was used for all four runs. Credentials have been redacted:
+**DockerHub (anonymous, no private registry):**
+```bash
+time enroot import docker://pytorch/pytorch:2.11.0-cuda12.8-cudnn9-devel
+```
 
+**In-cluster zot registry (credentials redacted):**
 ```bash
 time enroot import docker://<ZOT_USERNAME>:<ZOT_PASSWORD>@10.16.12.10:5000#pytorch/pytorch:2.11.0-cuda12.8-cudnn9-devel
 ```
@@ -48,66 +59,59 @@ The `#` delimiter separates the registry address from the image path — enroot'
 
 ### Time Breakdown per Phase (approximate)
 
-| Phase | Cold run | Warm run (enroot cache hit) |
-|---|---|---|
-| Layer download | ~35s | 0s (skipped) |
-| Layer extraction | ~26–27s | ~26–27s |
-| Whiteout conversion | ~1s | ~1s |
-| mksquashfs | ~44–49s | ~44–46s |
+| Phase | DockerHub cold | Zot cold (with or without LOTA) | Warm (enroot cache hit) |
+|---|---|---|---|
+| Layer download | ~62s | ~35s | 0s (skipped) |
+| Layer extraction | ~27s | ~26–27s | ~26–27s |
+| Whiteout conversion | ~1s | ~1s | ~1s |
+| mksquashfs | ~45s | ~44–49s | ~44–46s |
 
 ### Wall-Clock Time Comparison
 
 | Run | Configuration | real | user | sys | Download |
 |---|---|---|---|---|---|
-| 1st (cold) | Without LOTA | **1m 47.8s** | 4m 35.7s | 4m 14.3s | 10 layers (~35s) |
-| 2nd (warm) | Without LOTA | **1m 13.3s** | 2m 04.5s | 2m 11.4s | None (local cache) |
-| 1st (cold) | With LOTA | **1m 51.5s** | 4m 37.9s | 4m 26.1s | 10 layers (~35s) |
-| 2nd (warm) | With LOTA | **1m 13.5s** | 2m 04.2s | 2m 41.3s | None (local cache) |
+| 1st (cold) | DockerHub | **2m 15.6s** | 4m 34.8s | 4m 15.9s | 10 layers (~62s) |
+| 1st (cold) | Zot — Without LOTA | **1m 47.8s** | 4m 35.7s | 4m 14.3s | 10 layers (~35s) |
+| 1st (cold) | Zot — With LOTA | **1m 51.5s** | 4m 37.9s | 4m 26.1s | 10 layers (~35s) |
+| 2nd (warm) | Zot — Without LOTA | **1m 13.3s** | 2m 04.5s | 2m 11.4s | None (local cache) |
+| 2nd (warm) | Zot — With LOTA | **1m 13.5s** | 2m 04.2s | 2m 41.3s | None (local cache) |
 
 ---
 
 ## Analysis
 
-### Cold Run (First Import — No Caches Warm)
+### In-Cluster Zot vs. DockerHub (The Primary Finding)
 
-- **Without LOTA:** 1m 47.8s
-- **With LOTA:** 1m 51.5s — **+3.7s slower**
+The most significant result is the comparison between pulling from DockerHub and pulling from the in-cluster zot registry:
 
-The cold run behavior mirrors the `zb` benchmark findings: on first access, LOTA's cache is empty and every layer request proxies through LOTA to CAIOS, adding an extra network hop. For a 19 GB image across 10 layers, this overhead is only ~3.7 seconds — a negligible ~3.4% difference. The bulk of both runs is dominated by CPU-bound work (squashfs compression), not download time.
+| Source | Cold import time | Download phase | vs. DockerHub |
+|---|---|---|---|
+| DockerHub | 2m 15.6s | ~62s | baseline |
+| Zot — Without LOTA | 1m 47.8s | ~35s | **-27.8s / 20.5% faster** |
+| Zot — With LOTA | 1m 51.5s | ~35s | **-24.1s / 17.8% faster** |
 
-### Warm Run (Second Import — Enroot Local Cache Hit)
+The in-cluster zot registry nearly **halves the download time** (62s → 35s) regardless of whether LOTA is in use. This is the primary benefit of the registry: keeping images on-cluster eliminates the public internet round-trip and DockerHub rate limits. LOTA vs. no LOTA is a secondary consideration by comparison.
 
-- **Without LOTA:** 1m 13.3s
-- **With LOTA:** 1m 13.5s — **~0.2s difference (effectively identical)**
+### LOTA vs. No LOTA (Secondary Finding)
 
-On the second run, enroot's local layer cache (`~/.cache/enroot/`) eliminates the download entirely for both configurations — neither LOTA nor the registry is consulted. The remaining time (~73s) is entirely CPU-bound: layer extraction, whiteout processing, and parallel mksquashfs across 96 cores.
+Within the in-cluster zot runs, the difference between LOTA and no LOTA is small:
 
-This means **LOTA's caching does not benefit the second enroot import on the same node** — enroot's own local cache takes precedence and is faster than any network fetch, regardless of whether LOTA has a warm cache or not.
+- **Cold import:** 1m 47.8s (no LOTA) vs. 1m 51.5s (with LOTA) — **+3.7s with LOTA (+3.4%)**
+- **Warm import:** 1m 13.3s vs. 1m 13.5s — **effectively identical**
 
-### The Two Cache Layers
+On a cold pull, LOTA's cache is empty and every layer proxies through LOTA to CAIOS, adding a network hop. The 3.7s overhead is negligible on a ~108s operation dominated by CPU-bound squashfs compression.
 
-Understanding the interaction between the two caching systems is key:
+On a warm pull (enroot's own layer cache hit), neither LOTA nor the registry is contacted — the result is identical regardless of LOTA.
 
-| Cache | Scope | Benefit |
-|---|---|---|
-| **Enroot local cache** (`~/.cache/enroot/`) | Per-user, per-node | Eliminates download entirely on repeat imports by the same user on the same node |
-| **LOTA cache** (DaemonSet, per-node) | Per-node | Accelerates pulls from CAIOS for any user on the same node whose enroot cache is cold |
+### LOTA Benefit for Enroot Workflows
 
-LOTA runs as a **DaemonSet** — one instance per node — so its cache is node-local, not cluster-wide. A warm LOTA cache on Node A does not benefit Node B. However, within the same node, LOTA's value is clear in multi-user or multi-job scenarios.
+In practice, LOTA provides **no meaningful benefit** for enroot in a typical SLURM environment:
 
-#### SLURM Multi-User Scenario
+1. **Shared `.sqsh` on NFS:** The `.sqsh` output file is written to an NFS-mounted shared directory. Once any user imports an image, all other users and nodes reference that same file directly — no one else needs to run `enroot import` for that image again. LOTA's node-local cache is never consulted.
 
-In SLURM environments, each user has their own `$HOME`, so enroot's layer cache at `$HOME/.cache/enroot/` is **completely separate per user**. This means every distinct SLURM user that pulls the same image on the same node will have a cold enroot cache and will contact the registry again — even if another user on that node already pulled the exact same image minutes earlier.
+2. **Same-user repeat import:** If the same user does re-import, enroot's own layer cache (`$HOME/.cache/enroot/`) serves the layers locally, and the registry (LOTA or CAIOS) is never contacted.
 
-This is where LOTA's node-local DaemonSet cache provides direct value:
-
-| Step | Without LOTA | With LOTA |
-|---|---|---|
-| User A pulls image (node cold) | enroot cold → CAIOS (~35s download) | enroot cold → LOTA cold → CAIOS (~35s + proxy overhead) |
-| User B pulls same image, same node | enroot cold → CAIOS (~35s download) | enroot cold → **LOTA warm** → served from node-local cache |
-| User A pulls same image again | **enroot warm** → 0s download | **enroot warm** → 0s download |
-
-Without LOTA, every unique SLURM user pays the full CAIOS download cost for their first pull. With LOTA, only the first user on each node incurs that cost — all subsequent users on that node hit LOTA's warm cache instead.
+3. **SLURM multi-user scenario:** The previously assumed benefit — that LOTA's cache would serve a second SLURM user whose enroot cache is cold — does not apply in practice precisely because the `.sqsh` on NFS eliminates the need for re-importing entirely. A second user would simply use the existing `.sqsh` file rather than running `enroot import` again.
 
 ### sys Time on Warm LOTA Run
 
@@ -117,14 +121,15 @@ The warm LOTA run shows elevated `sys` time (2m 41.3s vs 2m 11.4s without LOTA).
 
 ## Summary
 
-| Scenario | Without LOTA | With LOTA | Delta |
+| Scenario | DockerHub | Zot (no LOTA) | Zot (with LOTA) |
 |---|---|---|---|
-| Cold import (first pull, no caches) | 1m 47.8s | 1m 51.5s | +3.7s (+3.4%) |
-| Warm import (enroot local cache hit) | 1m 13.3s | 1m 13.5s | ~equal |
+| Cold import | 2m 15.6s | 1m 47.8s | 1m 51.5s |
+| Warm import (enroot cache) | — | 1m 13.3s | 1m 13.5s |
+| Shared `.sqsh` reuse (NFS) | n/a | 0s (already imported) | 0s (already imported) |
 
 ### Key Takeaways
 
-1. **Cold import overhead with LOTA is minimal (~3.7s)** for a 19 GB, 10-layer image. The dominant cost is CPU-bound squashfs compression, not the download.
-2. **Warm runs are identical** regardless of LOTA, because enroot's local layer cache (`~/.cache/enroot/`) takes precedence — the registry is never contacted.
-3. **LOTA is a per-node DaemonSet, not a cluster-wide cache.** A warm LOTA cache on one node does not benefit other nodes. Its value is scoped to the node it runs on.
-4. **LOTA's enroot benefit is within-node, cross-user/cross-job:** the most practical use case is when a second user or SLURM job (different UID, different `$HOME`) imports the same image on the same node. Their enroot cache is cold, but LOTA's node-local cache is warm — serving layers locally instead of fetching from CAIOS again.
+1. **The in-cluster zot registry is the real win.** Pulling from zot is ~20% faster than DockerHub cold and cuts download time nearly in half by keeping images on-cluster and avoiding public internet latency and rate limits.
+2. **LOTA adds negligible overhead on cold pull (+3.7s) and no difference on warm pull.** The dominant cost in all runs is CPU-bound squashfs compression, not the download.
+3. **LOTA provides no practical benefit for enroot in SLURM.** The `.sqsh` file lands on NFS shared storage, so once any user imports an image it is immediately available to all other users and nodes without re-importing — bypassing both LOTA's cache and enroot's layer cache entirely.
+4. **LOTA is a per-node DaemonSet, not a cluster-wide cache.** Its cache does not carry across nodes, further limiting its utility in multi-node SLURM job environments.

--- a/zot-oci-registry-in-cluster/reports/sample-enroute-import.yaml
+++ b/zot-oci-registry-in-cluster/reports/sample-enroute-import.yaml
@@ -6,7 +6,7 @@ metadata:
 type: Opaque
 stringData:
   username: admin
-  password: GAC2026lot
+  password: xxxxx
 ---
 apiVersion: v1
 kind: Pod

--- a/zot-oci-registry-in-cluster/reports/sample-enroute-import.yaml
+++ b/zot-oci-registry-in-cluster/reports/sample-enroute-import.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: zot-credentials
+  namespace: kube-system
+type: Opaque
+stringData:
+  username: admin
+  password: GAC2026lot
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: enroot-test
+  namespace: kube-system
+spec:
+  containers:
+    - name: enroot
+      image: ubuntu:24.04
+      command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          apt-get update -q
+          apt-get install -y -q \
+            curl \
+            ca-certificates \
+            squashfs-tools \
+            parallel \
+            pigz \
+            libcap2-bin
+
+          curl -fSsL -O \
+            "https://github.com/NVIDIA/enroot/releases/download/v4.1.2/enroot_4.1.2-1_amd64.deb"
+          curl -fSsL -O \
+            "https://github.com/NVIDIA/enroot/releases/download/v4.1.2/enroot+caps_4.1.2-1_amd64.deb"
+          apt-get install -y ./enroot_4.1.2-1_amd64.deb
+          apt-get install -y ./enroot+caps_4.1.2-1_amd64.deb
+
+          cp /ca/ca.crt /usr/local/share/ca-certificates/zot-internal-ca.crt
+          update-ca-certificates
+          enroot import docker://${ZOT_USERNAME}:${ZOT_PASSWORD}@10.16.12.10:5000#library/nginx:stable
+          sleep infinity
+      env:
+        - name: ZOT_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: zot-credentials
+              key: username
+        - name: ZOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: zot-credentials
+              key: password
+      securityContext:
+        privileged: true
+      volumeMounts:
+        - name: ca-secret
+          mountPath: /ca
+          readOnly: true
+  restartPolicy: Never
+  volumes:
+    - name: ca-secret
+      secret:
+        secretName: zot-infra-ca-secret
+        items:
+          - key: ca.crt
+            path: ca.crt

--- a/zot-oci-registry-in-cluster/reports/sample-enroute-import.yaml
+++ b/zot-oci-registry-in-cluster/reports/sample-enroute-import.yaml
@@ -6,7 +6,7 @@ metadata:
 type: Opaque
 stringData:
   username: admin
-  password: xxxxx
+  password: ZOT_PASSWORD
 ---
 apiVersion: v1
 kind: Pod
@@ -40,7 +40,7 @@ spec:
 
           cp /ca/ca.crt /usr/local/share/ca-certificates/zot-internal-ca.crt
           update-ca-certificates
-          enroot import docker://${ZOT_USERNAME}:${ZOT_PASSWORD}@10.16.12.10:5000#library/nginx:stable
+          enroot import docker://${ZOT_USERNAME}:${ZOT_PASSWORD}@ZOT_INTERNAL_LB_SVC_IP:5000#library/nginx:stable
           sleep infinity
       env:
         - name: ZOT_USERNAME
@@ -54,6 +54,27 @@ spec:
               name: zot-credentials
               key: password
       securityContext:
+        # privileged: true is required for enroot import to function inside a Kubernetes pod.
+        # enroot's import pipeline needs capabilities that cannot be satisfied individually
+        # under Kubernetes's default seccomp/AppArmor restrictions:
+        #
+        # 1. CAP_MKNOD — enroot converts OCI layer whiteout files (AUFS `.wh.*` prefix files)
+        #    into overlayfs-style character devices with major:minor 0:0 via mknod(). Without
+        #    this, layer deletion markers cannot be processed correctly.
+        #
+        # 2. CAP_SYS_ADMIN — mksquashfs must create device inodes and perform mount operations
+        #    when packaging image layers into the .sqsh SquashFS image. SquashFS cannot be
+        #    mounted inside an unprivileged user namespace.
+        #
+        # 3. unshare() syscall — enroot uses Linux mount namespaces during extraction and
+        #    layer merging. This syscall is blocked by Kubernetes's default seccomp profile
+        #    for unprivileged containers.
+        #
+        # The enroot+caps package (installed above) sets file capabilities on enroot binaries
+        # to allow unprivileged operation on bare-metal SLURM nodes, but this is insufficient
+        # inside a Kubernetes pod because: seccomp filters block unshare(), extended attribute
+        # capabilities are cleared when crossing user namespace boundaries, and overlayfs
+        # blocks device creation for unprivileged containers regardless of capability grants.
         privileged: true
       volumeMounts:
         - name: ca-secret

--- a/zot-oci-registry-in-cluster/reports/zb-bencharmarking.yaml
+++ b/zot-oci-registry-in-cluster/reports/zb-bencharmarking.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: zot-benchmark
+  namespace: zot-registry
+spec:
+  ttlSecondsAfterFinished: 3600
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      volumes:
+        - name: ca-cert
+          secret:
+            secretName: zot-infra-ca-secret
+            items:
+              - key: ca.crt
+                path: zot-internal-ca.crt
+      containers:
+        - name: zb
+          image: ubuntu:24.04
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              apt-get update -qq && apt-get install -y -qq wget ca-certificates && \
+              cp /etc/ca-certs/zot-internal-ca.crt /usr/local/share/ca-certificates/zot-internal-ca.crt && \
+              update-ca-certificates && \
+              wget -qO /usr/local/bin/zb \
+                https://github.com/project-zot/zot/releases/download/v2.1.15/zb-linux-amd64 && \
+              chmod +x /usr/local/bin/zb && \
+              zb \
+                -c 1 \
+                -n 3 \
+                -A "$(ZOT_CREDS)" \
+                -d /tmp/zb-workdir \
+                "$(ZOT_URL)"
+          env:
+            - name: ZOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: zot-benchmark-creds
+                  key: username
+            - name: ZOT_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: zot-benchmark-creds
+                  key: password
+            - name: ZOT_CREDS
+              value: "$(ZOT_USER):$(ZOT_PASS)"
+            - name: ZOT_URL
+              value: "https://10.16.12.10:5000"
+          volumeMounts:
+            - name: ca-cert
+              mountPath: /etc/ca-certs
+              readOnly: true
+          resources:
+            limits:
+              cpu: 4
+              memory: 4Gi

--- a/zot-oci-registry-in-cluster/reports/zb-benchmark-with-lota.txt
+++ b/zot-oci-registry-in-cluster/reports/zb-benchmark-with-lota.txt
@@ -1,0 +1,288 @@
+Registry URL: https://10.16.12.10:5000
+
+Concurrency Level: 1
+Total requests:    3
+Working dir:       /tmp/zb-workdir
+
+Preparing test data ...
+Starting tests ...
+============
+Test name:            Get Catalog
+Time taken for tests: 30.164086689s
+Requests per second:  0.09945602
+Complete requests:    3
+Failed requests:      0
+
+1MB:   1
+10MB:  0
+100MB: 2
+
+2xx responses: 3
+
+min: 7.655858848s
+max: 7.846655162s
+p50: 7.791893952s
+p75: 7.846655162s
+p90: 7.846655162s
+p99: 7.846655162s
+
+============
+Test name:            Push Monolith 1MB
+Time taken for tests: 3.283503075s
+Requests per second:  0.9136584
+Complete requests:    3
+Failed requests:      0
+
+2xx responses: 3
+
+min: 779.118216ms
+max: 825.408872ms
+p50: 789.994857ms
+p75: 825.408872ms
+p90: 825.408872ms
+p99: 825.408872ms
+
+============
+Test name:            Push Monolith 10MB
+Time taken for tests: 3.978252604s
+Requests per second:  0.7540999
+Complete requests:    3
+Failed requests:      0
+
+2xx responses: 3
+
+min: 870.449108ms
+max: 1.193524359s
+p50: 917.596422ms
+p75: 1.193524359s
+p90: 1.193524359s
+p99: 1.193524359s
+
+============
+Test name:            Push Monolith 100MB
+Time taken for tests: 7.453528853s
+Requests per second:  0.40249392
+Complete requests:    3
+Failed requests:      0
+
+2xx responses: 3
+
+min: 2.105201681s
+max: 2.120655215s
+p50: 2.10819233s
+p75: 2.120655215s
+p90: 2.120655215s
+p99: 2.120655215s
+
+============
+Test name:            Push Chunk Streamed 1MB
+Time taken for tests: 3.56745745s
+Requests per second:  0.84093505
+Complete requests:    3
+Failed requests:      0
+
+2xx responses: 3
+
+min: 845.46812ms
+max: 913.456007ms
+p50: 880.644286ms
+p75: 913.456007ms
+p90: 913.456007ms
+p99: 913.456007ms
+
+============
+Test name:            Push Chunk Streamed 10MB
+Time taken for tests: 4.041172782s
+Requests per second:  0.74235874
+Complete requests:    3
+Failed requests:      0
+
+2xx responses: 3
+
+min: 955.049531ms
+max: 1.032837012s
+p50: 1.007249372s
+p75: 1.032837012s
+p90: 1.032837012s
+p99: 1.032837012s
+
+============
+Test name:            Push Chunk Streamed 100MB
+Time taken for tests: 8.448145052s
+Requests per second:  0.35510755
+Complete requests:    3
+Failed requests:      0
+
+2xx responses: 3
+
+min: 2.265365013s
+max: 2.802797512s
+p50: 2.383979615s
+p75: 2.802797512s
+p90: 2.802797512s
+p99: 2.802797512s
+
+============
+Test name:            Pull 1MB
+Time taken for tests: 1.379478695s
+Requests per second:  2.1747346
+Complete requests:    3
+Failed requests:      0
+
+2xx responses: 3
+
+min: 90.241916ms
+max: 106.107297ms
+p50: 98.606862ms
+p75: 106.107297ms
+p90: 106.107297ms
+p99: 106.107297ms
+
+============
+Test name:            Pull 10MB
+Time taken for tests: 1.771022838s
+Requests per second:  1.6939365
+Complete requests:    3
+Failed requests:      0
+
+2xx responses: 3
+
+min: 116.599132ms
+max: 227.261669ms
+p50: 120.865146ms
+p75: 227.261669ms
+p90: 227.261669ms
+p99: 227.261669ms
+
+============
+Test name:            Pull 100MB
+Time taken for tests: 6.394873173s
+Requests per second:  0.4691258
+Complete requests:    3
+Failed requests:      0
+
+2xx responses: 3
+
+min: 986.783944ms
+max: 1.742591191s
+p50: 1.066202184s
+p75: 1.742591191s
+p90: 1.742591191s
+p99: 1.742591191s
+
+============
+Test name:            Pull Mixed 20% 1MB, 70% 10MB, 10% 100MB
+Time taken for tests: 4.563363146s
+Requests per second:  0.6574099
+Complete requests:    3
+Failed requests:      0
+
+1MB:   0
+10MB:  3
+100MB: 0
+
+2xx responses: 3
+
+min: 150.479829ms
+max: 172.716844ms
+p50: 152.183163ms
+p75: 172.716844ms
+p90: 172.716844ms
+p99: 172.716844ms
+
+============
+Test name:            Push Monolith Mixed 20% 1MB, 70% 10MB, 10% 100MB
+Time taken for tests: 4.784626979s
+Requests per second:  0.62700814
+Complete requests:    3
+Failed requests:      0
+
+1MB:   0
+10MB:  2
+100MB: 1
+
+2xx responses: 3
+
+min: 848.770194ms
+max: 2.130611035s
+p50: 932.822403ms
+p75: 2.130611035s
+p90: 2.130611035s
+p99: 2.130611035s
+
+============
+Test name:            Push Chunk Mixed 33% 1MB, 33% 10MB, 33% 100MB
+Time taken for tests: 5.327879397s
+Requests per second:  0.5630758
+Complete requests:    3
+Failed requests:      0
+
+1MB:   1
+10MB:  1
+100MB: 1
+
+2xx responses: 3
+
+min: 938.222853ms
+max: 2.239970722s
+p50: 1.218891558s
+p75: 2.239970722s
+p90: 2.239970722s
+p99: 2.239970722s
+
+============
+Test name:            Pull 75% and Push 25% Mixed 1MB
+Time taken for tests: 1.338710482s
+Requests per second:  2.2409625
+Complete requests:    3
+Failed requests:      0
+
+Pull: 3
+Push: 0
+
+2xx responses: 3
+
+min: 85.873938ms
+max: 97.635822ms
+p50: 95.807694ms
+p75: 97.635822ms
+p90: 97.635822ms
+p99: 97.635822ms
+
+============
+Test name:            Pull 75% and Push 25% Mixed 10MB
+Time taken for tests: 2.639498096s
+Requests per second:  1.1365798
+Complete requests:    3
+Failed requests:      0
+
+Pull: 1
+Push: 0
+
+2xx responses: 3
+
+min: 112.231996ms
+max: 939.548616ms
+p50: 113.981207ms
+p75: 939.548616ms
+p90: 939.548616ms
+p99: 939.548616ms
+
+============
+Test name:            Pull 75% and Push 25% Mixed 100MB
+Time taken for tests: 3.232342436s
+Requests per second:  0.9281195
+Complete requests:    3
+Failed requests:      0
+
+Pull: 3
+Push: 0
+
+2xx responses: 3
+
+min: 192.071902ms
+max: 395.955795ms
+p50: 275.428997ms
+p75: 395.955795ms
+p90: 395.955795ms
+p99: 395.955795ms

--- a/zot-oci-registry-in-cluster/reports/zb-benchmark-without-lota.txt
+++ b/zot-oci-registry-in-cluster/reports/zb-benchmark-without-lota.txt
@@ -1,0 +1,288 @@
+Registry URL: https://10.16.12.10:5000
+
+Concurrency Level: 1
+Total requests:    3
+Working dir:       /tmp/zb-workdir
+
+Preparing test data ...
+Starting tests ...
+============
+Test name:            Get Catalog
+Time taken for tests: 29.07848461s
+Requests per second:  0.10316906
+Complete requests:    3
+Failed requests:      0
+
+1MB:   3
+10MB:  0
+100MB: 0
+
+2xx responses: 3
+
+min: 7.505890259s
+max: 8.895286817s
+p50: 8.68616535s
+p75: 8.895286817s
+p90: 8.895286817s
+p99: 8.895286817s
+
+============
+Test name:            Push Monolith 1MB
+Time taken for tests: 5.79876522s
+Requests per second:  0.5173515
+Complete requests:    3
+Failed requests:      0
+
+2xx responses: 3
+
+min: 878.651711ms
+max: 1.004300458s
+p50: 934.585575ms
+p75: 1.004300458s
+p90: 1.004300458s
+p99: 1.004300458s
+
+============
+Test name:            Push Monolith 10MB
+Time taken for tests: 4.591955034s
+Requests per second:  0.6533165
+Complete requests:    3
+Failed requests:      0
+
+2xx responses: 3
+
+min: 1.025693872s
+max: 1.260417642s
+p50: 1.152349224s
+p75: 1.260417642s
+p90: 1.260417642s
+p99: 1.260417642s
+
+============
+Test name:            Push Monolith 100MB
+Time taken for tests: 9.820995546s
+Requests per second:  0.30546802
+Complete requests:    3
+Failed requests:      0
+
+2xx responses: 3
+
+min: 2.182520169s
+max: 3.761674469s
+p50: 2.356137925s
+p75: 3.761674469s
+p90: 3.761674469s
+p99: 3.761674469s
+
+============
+Test name:            Push Chunk Streamed 1MB
+Time taken for tests: 4.142305995s
+Requests per second:  0.7242343
+Complete requests:    3
+Failed requests:      0
+
+2xx responses: 3
+
+min: 926.573228ms
+max: 972.358365ms
+p50: 938.270485ms
+p75: 972.358365ms
+p90: 972.358365ms
+p99: 972.358365ms
+
+============
+Test name:            Push Chunk Streamed 10MB
+Time taken for tests: 5.860400158s
+Requests per second:  0.51191044
+Complete requests:    3
+Failed requests:      0
+
+2xx responses: 3
+
+min: 1.001571356s
+max: 1.301879368s
+p50: 1.10725124s
+p75: 1.301879368s
+p90: 1.301879368s
+p99: 1.301879368s
+
+============
+Test name:            Push Chunk Streamed 100MB
+Time taken for tests: 9.518508138s
+Requests per second:  0.31517544
+Complete requests:    3
+Failed requests:      0
+
+2xx responses: 3
+
+min: 2.287793304s
+max: 2.363990432s
+p50: 2.359623537s
+p75: 2.363990432s
+p90: 2.363990432s
+p99: 2.363990432s
+
+============
+Test name:            Pull 1MB
+Time taken for tests: 2.052925238s
+Requests per second:  1.4613293
+Complete requests:    3
+Failed requests:      0
+
+2xx responses: 3
+
+min: 112.202352ms
+max: 228.835416ms
+p50: 148.005681ms
+p75: 228.835416ms
+p90: 228.835416ms
+p99: 228.835416ms
+
+============
+Test name:            Pull 10MB
+Time taken for tests: 4.198070726s
+Requests per second:  0.71461403
+Complete requests:    3
+Failed requests:      0
+
+2xx responses: 3
+
+min: 124.903137ms
+max: 213.658538ms
+p50: 125.952625ms
+p75: 213.658538ms
+p90: 213.658538ms
+p99: 213.658538ms
+
+============
+Test name:            Pull 100MB
+Time taken for tests: 4.207856637s
+Requests per second:  0.712952
+Complete requests:    3
+Failed requests:      0
+
+2xx responses: 3
+
+min: 339.204463ms
+max: 578.222626ms
+p50: 473.377146ms
+p75: 578.222626ms
+p90: 578.222626ms
+p99: 578.222626ms
+
+============
+Test name:            Pull Mixed 20% 1MB, 70% 10MB, 10% 100MB
+Time taken for tests: 4.50097433s
+Requests per second:  0.6665224
+Complete requests:    3
+Failed requests:      0
+
+1MB:   1
+10MB:  2
+100MB: 0
+
+2xx responses: 3
+
+min: 88.480768ms
+max: 103.221229ms
+p50: 97.14935ms
+p75: 103.221229ms
+p90: 103.221229ms
+p99: 103.221229ms
+
+============
+Test name:            Push Monolith Mixed 20% 1MB, 70% 10MB, 10% 100MB
+Time taken for tests: 4.236615406s
+Requests per second:  0.7081125
+Complete requests:    3
+Failed requests:      0
+
+1MB:   2
+10MB:  1
+100MB: 0
+
+2xx responses: 3
+
+min: 951.86902ms
+max: 1.248000803s
+p50: 979.861036ms
+p75: 1.248000803s
+p90: 1.248000803s
+p99: 1.248000803s
+
+============
+Test name:            Push Chunk Mixed 33% 1MB, 33% 10MB, 33% 100MB
+Time taken for tests: 6.833829713s
+Requests per second:  0.4389925
+Complete requests:    3
+Failed requests:      0
+
+1MB:   1
+10MB:  1
+100MB: 1
+
+2xx responses: 3
+
+min: 1.170011219s
+max: 2.383789851s
+p50: 2.268567067s
+p75: 2.383789851s
+p90: 2.383789851s
+p99: 2.383789851s
+
+============
+Test name:            Pull 75% and Push 25% Mixed 1MB
+Time taken for tests: 4.341957984s
+Requests per second:  0.6909325
+Complete requests:    3
+Failed requests:      0
+
+Pull: 2
+Push: 0
+
+2xx responses: 3
+
+min: 94.84083ms
+max: 1.069396027s
+p50: 1.03532959s
+p75: 1.069396027s
+p90: 1.069396027s
+p99: 1.069396027s
+
+============
+Test name:            Pull 75% and Push 25% Mixed 10MB
+Time taken for tests: 1.91164685s
+Requests per second:  1.5693275
+Complete requests:    3
+Failed requests:      0
+
+Pull: 3
+Push: 0
+
+2xx responses: 3
+
+min: 96.240914ms
+max: 177.926556ms
+p50: 149.472376ms
+p75: 177.926556ms
+p90: 177.926556ms
+p99: 177.926556ms
+
+============
+Test name:            Pull 75% and Push 25% Mixed 100MB
+Time taken for tests: 6.752010366s
+Requests per second:  0.44431213
+Complete requests:    3
+Failed requests:      0
+
+Pull: 2
+Push: 0
+
+2xx responses: 3
+
+min: 341.888357ms
+max: 2.348039039s
+p50: 382.294065ms
+p75: 2.348039039s
+p90: 2.348039039s
+p99: 2.348039039s

--- a/zot-oci-registry-in-cluster/reports/zb-benchmark.md
+++ b/zot-oci-registry-in-cluster/reports/zb-benchmark.md
@@ -1,0 +1,129 @@
+# Zot Registry Benchmark Report: With LOTA vs. Without LOTA
+
+## Overview
+
+This report analyzes the performance of a zot OCI registry backed by two different storage endpoints:
+
+- **With LOTA** — zot configured to use CoreWeave's [Large Object Transfer Acceleration](http://cwlota.com) (`cwlota.com`), an accelerated S3-compatible endpoint optimized for GPU infrastructure workloads.
+- **Without LOTA** — zot configured to use standard CoreWeave AI Object Storage (CAIOS) via `cwobject.com`.
+
+LOTA runs as a **DaemonSet** (one instance per node), acting as a node-local acceleration layer in front of CAIOS: requests go through the node's LOTA instance first, and on a cache miss, LOTA fetches from CAIOS and caches the result for subsequent reads on that same node.
+
+### Cold Cache Caveat
+
+> **Important:** `zb` generates new unique objects on every test run. This means LOTA's cache is always cold during these benchmarks — every pull request results in a cache miss and a full proxy pass-through to CAIOS. This adds an extra network hop compared to hitting CAIOS directly, which explains the pull latency regressions observed below. In production workloads where the same images are pulled repeatedly, LOTA's cache would warm up and pull performance is expected to improve significantly.
+
+---
+
+## Test Environment
+
+| Parameter | Value |
+|---|---|
+| Registry URL | `https://10.16.12.10:5000` |
+| Concurrency Level | 1 |
+| Total requests per test | 3 |
+| Tool | `zb` v2.1.15 |
+| Working directory | `/tmp/zb-workdir` |
+
+---
+
+## Results
+
+### Get Catalog
+
+| Metric | With LOTA | Without LOTA |
+|---|---|---|
+| Time taken | 30.16s | 29.08s |
+| Requests/sec | 0.099 | 0.103 |
+| p50 latency | 7.79s | 8.69s |
+| p99 latency | 7.85s | 8.90s |
+| Failed requests | 0 | 0 |
+
+Catalog retrieval performance is comparable between both configurations.
+
+---
+
+### Push — Monolith
+
+| Test | With LOTA p50 | Without LOTA p50 | With LOTA req/s | Without LOTA req/s | Improvement |
+|---|---|---|---|---|---|
+| Push Monolith 1MB | 790ms | 935ms | 0.91 | 0.52 | **-15.5% latency / +75% throughput** |
+| Push Monolith 10MB | 918ms | 1.15s | 0.75 | 0.65 | **-20.3% latency / +15% throughput** |
+| Push Monolith 100MB | 2.11s | 2.36s | 0.40 | 0.31 | **-10.6% latency / +31.6% throughput** |
+
+LOTA consistently improves push latency and throughput across all image sizes. The acceleration is most pronounced at 1MB and 10MB.
+
+---
+
+### Push — Chunk Streamed
+
+| Test | With LOTA p50 | Without LOTA p50 | With LOTA req/s | Without LOTA req/s | Improvement |
+|---|---|---|---|---|---|
+| Push Chunk 1MB | 881ms | 938ms | 0.84 | 0.72 | **-6.1% latency / +16.7% throughput** |
+| Push Chunk 10MB | 1.01s | 1.11s | 0.74 | 0.51 | **-9.1% latency / +45% throughput** |
+| Push Chunk 100MB | 2.38s | 2.36s | 0.36 | 0.32 | ~equal latency / **+12.5% throughput** |
+
+Chunked streaming shows similar gains. At 100MB, latency is equivalent but throughput still favors LOTA.
+
+---
+
+### Pull
+
+| Test | With LOTA p50 | Without LOTA p50 | With LOTA req/s | Without LOTA req/s | Note |
+|---|---|---|---|---|---|
+| Pull 1MB | 99ms | 148ms | 2.17 | 1.46 | **-33% latency / +48.6% throughput** |
+| Pull 10MB | 121ms | 126ms | 1.69 | 0.71 | **-4% latency / +138% throughput** |
+| Pull 100MB | 1.07s | 473ms | 0.47 | 0.71 | Cold cache overhead (see note below) |
+
+**Pull 100MB regression explained:** Since `zb` creates new objects each run, LOTA's cache is never warm. For a 100MB pull, the cold cache miss causes LOTA to proxy the full object from CAIOS, adding the latency of an extra network hop vs. hitting CAIOS directly. This regression is an artifact of the benchmark methodology and is not representative of steady-state production pull performance.
+
+---
+
+### Mixed Workloads — Pull Only
+
+| Test | With LOTA p50 | Without LOTA p50 | Note |
+|---|---|---|---|
+| Pull Mixed (20% 1MB, 70% 10MB, 10% 100MB) | 152ms | 97ms | Cold cache; majority 10MB traffic |
+
+The mixed pull result skews slower with LOTA for the same cold cache reason — the 100MB slice adds disproportionate latency on cache miss.
+
+---
+
+### Mixed Workloads — Push Only
+
+| Test | With LOTA p50 | Without LOTA p50 | With LOTA req/s | Without LOTA req/s | Improvement |
+|---|---|---|---|---|---|
+| Push Monolith Mixed (20% 1MB, 70% 10MB, 10% 100MB) | 933ms | 980ms | 0.63 | 0.71 | -4.8% latency |
+| Push Chunk Mixed (33% 1MB, 33% 10MB, 33% 100MB) | 1.22s | 2.27s | 0.56 | 0.44 | **-46.3% latency / +27.3% throughput** |
+
+Push Chunk Mixed shows the most dramatic improvement with LOTA — nearly half the latency.
+
+---
+
+### Mixed Workloads — Pull 75% / Push 25%
+
+| Test | With LOTA p50 | Without LOTA p50 | With LOTA req/s | Without LOTA req/s | Improvement |
+|---|---|---|---|---|---|
+| Pull 75% / Push 25% — 1MB | 96ms | 1.04s | 2.24 | 0.69 | **-91% latency / +225% throughput** |
+| Pull 75% / Push 25% — 10MB | 114ms | 149ms | 1.14 | 1.57 | -23.5% latency |
+| Pull 75% / Push 25% — 100MB | 275ms | 382ms | 0.93 | 0.44 | **-28% latency / +111% throughput** |
+
+The 1MB mixed scenario shows the most dramatic benefit from LOTA, with p50 latency dropping from 1.04s to 96ms — a 10x improvement. The 100MB mixed test also benefits significantly, suggesting that when push activity is included, LOTA's write path acceleration more than compensates for any pull overhead.
+
+---
+
+## Summary
+
+| Category | LOTA Benefit |
+|---|---|
+| Push (all sizes) | Consistent latency and throughput improvement |
+| Pull — small objects (1MB, 10MB) | Clear improvement in latency and throughput |
+| Pull — large objects (100MB) | Regression due to cold cache; proxy hop adds latency |
+| Mixed Push+Pull workloads | Strong improvement, especially at 1MB and 100MB |
+
+### Key Takeaways
+
+1. **LOTA accelerates push operations** across all image sizes, with throughput gains ranging from 12% to 75%.
+2. **Pull performance benefits are cache-dependent.** The `zb` tool generates new objects per test, ensuring a perpetual cold cache. In real registry usage where the same objects are pulled repeatedly on the same node, LOTA's node-local cache warms up and pull performance improves. Note that LOTA's cache does not carry over to other nodes.
+3. **Mixed workloads favor LOTA strongly.** Real-world registry traffic (a mix of pushes and repeated pulls) aligns well with LOTA's design — the write path benefits are immediate, and the read path improves as the cache warms.
+4. **The 100MB pull regression is a benchmark artifact**, not a production concern. It reflects the cost of LOTA proxying an uncached object through to CAIOS, which adds one extra network hop relative to hitting CAIOS directly.

--- a/zot-oci-registry-in-cluster/reports/zb-benchmark.md
+++ b/zot-oci-registry-in-cluster/reports/zb-benchmark.md
@@ -11,7 +11,13 @@ LOTA runs as a **DaemonSet** (one instance per node), acting as a node-local acc
 
 ### Cold Cache Caveat
 
-> **Important:** `zb` generates new unique objects on every test run. This means LOTA's cache is always cold during these benchmarks — every pull request results in a cache miss and a full proxy pass-through to CAIOS. This adds an extra network hop compared to hitting CAIOS directly, which explains the pull latency regressions observed below. In production workloads where the same images are pulled repeatedly, LOTA's cache would warm up and pull performance is expected to improve significantly.
+> **Important:** `zb` generates new unique objects on every test run, so LOTA's cache is perpetually cold for all pull operations — every read is a cache miss that proxies through LOTA to CAIOS, adding an extra network hop vs. hitting CAIOS directly.
+>
+> Push operations consistently improved with LOTA across all sizes. This is expected: writes are acknowledged by the LOTA DaemonSet process running locally on the node, reducing observed write latency before the data is fully persisted to CAIOS.
+>
+> Cold pull behavior was asymmetric by object size:
+> - **Small objects (1MB, 10MB):** Still faster with LOTA, even cold. LOTA maintains persistent authenticated connections to CAIOS, so the connection setup cost is already absorbed — the request is one fast local hop away from an already-open pipe.
+> - **Large objects (100MB):** Slower with LOTA when cold. At that size the connection reuse benefit is negligible, and the cost of buffering 100MB through LOTA as a proxy layer outweighs any gain.
 
 ---
 
@@ -123,7 +129,7 @@ The 1MB mixed scenario shows the most dramatic benefit from LOTA, with p50 laten
 
 ### Key Takeaways
 
-1. **LOTA accelerates push operations** across all image sizes, with throughput gains ranging from 12% to 75%.
-2. **Pull performance benefits are cache-dependent.** The `zb` tool generates new objects per test, ensuring a perpetual cold cache. In real registry usage where the same objects are pulled repeatedly on the same node, LOTA's node-local cache warms up and pull performance improves. Note that LOTA's cache does not carry over to other nodes.
-3. **Mixed workloads favor LOTA strongly.** Real-world registry traffic (a mix of pushes and repeated pulls) aligns well with LOTA's design — the write path benefits are immediate, and the read path improves as the cache warms.
-4. **The 100MB pull regression is a benchmark artifact**, not a production concern. It reflects the cost of LOTA proxying an uncached object through to CAIOS, which adds one extra network hop relative to hitting CAIOS directly.
+1. **LOTA accelerates push operations** across all image sizes, with throughput gains ranging from 12% to 75%, by acknowledging writes locally before persisting to CAIOS.
+2. **Cold pull behavior is asymmetric by size.** Small objects benefit from LOTA's persistent connections to CAIOS absorbing connection setup overhead. Large objects regress because buffering through the proxy layer at that size costs more than any connection reuse saves.
+3. **For Kubernetes workloads (containerd), LOTA provides limited ongoing benefit.** After the first cold pull, containerd and kubelet cache the image layers on the node — subsequent pod starts never contact the registry again. LOTA would also retain a copy of the same data, resulting in the image being stored twice on the same node with no access advantage.
+4. **The clearest LOTA benefit is for multiple SLURM users on the same node running enroot.** Each SLURM user has a separate enroot cache under their own `$HOME`, so every distinct user pays the full download cost on their first pull. With LOTA's node-local cache warm from the first user, all subsequent users on that node are served locally without hitting CAIOS again.

--- a/zot-oci-registry-in-cluster/reports/zb-benchmarking.yaml
+++ b/zot-oci-registry-in-cluster/reports/zb-benchmarking.yaml
@@ -48,7 +48,7 @@ spec:
             - name: ZOT_CREDS
               value: "$(ZOT_USER):$(ZOT_PASS)"
             - name: ZOT_URL
-              value: "https://10.16.12.10:5000"
+              value: "https://ZOT_INTERNAL_LB_SVC_IP:5000"
           volumeMounts:
             - name: ca-cert
               mountPath: /etc/ca-certs

--- a/zot-oci-registry-in-cluster/templates/NOTES.txt
+++ b/zot-oci-registry-in-cluster/templates/NOTES.txt
@@ -1,0 +1,47 @@
+zot-infra deployed. Run the following to verify each component:
+
+─── Internal CA ──────────────────────────────────────────────────────────────
+
+  kubectl get clusterissuer {{ include "zot-infra.caIssuerName" . }}
+  # Expected: READY=True
+
+  kubectl get certificate {{ include "zot-infra.caName" . }} -n {{ .Values.namespaces.certManager }}
+  # Expected: READY=True, SECRET={{ include "zot-infra.caSecretName" . }}
+
+─── Internal Gateway ─────────────────────────────────────────────────────────
+
+  kubectl get gateway {{ include "zot-infra.internalGwName" . }} -n {{ .Values.namespaces.kgateway }}
+  # Expected: PROGRAMMED=True, ADDRESS={{ .Values.internalGateway.lbIP }}
+
+  kubectl get certificate {{ include "zot-infra.internalCertName" . }} -n {{ .Values.namespaces.kgateway }}
+  # Expected: READY=True, SECRET={{ include "zot-infra.internalCertSecretName" . }}
+
+  kubectl get svc {{ include "zot-infra.internalGwName" . }} -n {{ .Values.namespaces.kgateway }}
+  # Expected: EXTERNAL-IP={{ .Values.internalGateway.lbIP }}
+
+  kubectl get httproute {{ include "zot-infra.internalRouteName" . }} -n {{ .Values.namespaces.zot }}
+
+─── External Gateway ─────────────────────────────────────────────────────────
+
+  kubectl get gateway {{ include "zot-infra.externalGwName" . }} -n {{ .Values.namespaces.kgateway }}
+  # Expected: PROGRAMMED=True
+
+  kubectl get certificate {{ include "zot-infra.externalCertSecretName" . }} -n {{ .Values.namespaces.kgateway }}
+  # Expected: READY=True
+
+  kubectl get httproute {{ include "zot-infra.externalRouteName" . }} -n {{ .Values.namespaces.zot }}
+  # Expected: HOSTNAMES=[registry.{{ .Values.externalGateway.clusterOrgHostname }}.coreweave.app]
+
+─── containerd DaemonSet ─────────────────────────────────────────────────────
+
+  kubectl get ds {{ include "zot-infra.dsName" . }} -n {{ .Values.namespaces.certManager }}
+  # Expected: DESIRED == CURRENT == READY
+
+  # Confirm files written on a node:
+  #   cwic node shell WORKER_NODE_ID
+  #   ls /etc/containerd/certs.d/{{ .Values.internalGateway.lbIP }}:{{ .Values.internalGateway.port }}/
+  #   Expected: ca.crt  hosts.toml
+
+─── CA Rotation ──────────────────────────────────────────────────────────────
+
+  kubectl -n {{ .Values.namespaces.certManager }} rollout restart ds/{{ include "zot-infra.dsName" . }}

--- a/zot-oci-registry-in-cluster/templates/_helpers.tpl
+++ b/zot-oci-registry-in-cluster/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{/*
+All Kubernetes resource names are derived from the Helm release name so that
+multiple installs of this chart in the same cluster do not collide.
+
+Usage: {{ include "zot-infra.caSecretName" . }}
+*/}}
+
+{{/* ── Internal CA ───────────────────────────────────────────────────────── */}}
+{{- define "zot-infra.caName" -}}{{ .Release.Name }}-ca{{- end }}
+{{- define "zot-infra.caSecretName" -}}{{ .Release.Name }}-ca-secret{{- end }}
+{{- define "zot-infra.caIssuerName" -}}{{ .Release.Name }}-ca-issuer{{- end }}
+
+{{/* ── Internal Gateway ──────────────────────────────────────────────────── */}}
+{{- define "zot-infra.internalGwParamsName" -}}{{ .Release.Name }}-internal-gw-params{{- end }}
+{{- define "zot-infra.internalGwName" -}}{{ .Release.Name }}-internal-gateway{{- end }}
+{{- define "zot-infra.internalCertName" -}}{{ .Release.Name }}-internal-cert{{- end }}
+{{- define "zot-infra.internalCertSecretName" -}}{{ .Release.Name }}-internal-cert-secret{{- end }}
+{{- define "zot-infra.internalRouteName" -}}{{ .Release.Name }}-internal-route{{- end }}
+
+{{/* ── External Gateway ──────────────────────────────────────────────────── */}}
+{{- define "zot-infra.externalGwParamsName" -}}{{ .Release.Name }}-external-gw-params{{- end }}
+{{- define "zot-infra.externalGwName" -}}{{ .Release.Name }}-external-gateway{{- end }}
+{{- define "zot-infra.externalCertSecretName" -}}{{ .Release.Name }}-public-cert-secret{{- end }}
+{{- define "zot-infra.externalRouteName" -}}{{ .Release.Name }}-external-route{{- end }}
+
+{{/* ── DaemonSet ─────────────────────────────────────────────────────────── */}}
+{{- define "zot-infra.dsName" -}}{{ .Release.Name }}-containerd-ds{{- end }}
+{{- define "zot-infra.dsCmName" -}}{{ .Release.Name }}-containerd-hosts-cm{{- end }}

--- a/zot-oci-registry-in-cluster/templates/ca-bootstrap.yaml
+++ b/zot-oci-registry-in-cluster/templates/ca-bootstrap.yaml
@@ -1,0 +1,33 @@
+{{- /*
+  Internal CA Bootstrap — namespaces.certManager
+  Creates:
+    1. A self-signed CA Certificate (isCA: true)
+    2. A ClusterIssuer backed by that CA
+  The internal leaf Certificate will be retried by cert-manager automatically
+  once the ClusterIssuer reaches READY=True.
+*/ -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "zot-infra.caName" . }}
+  namespace: {{ .Values.namespaces.certManager }}
+spec:
+  isCA: true
+  commonName: {{ include "zot-infra.caName" . }}
+  secretName: {{ include "zot-infra.caSecretName" . }}
+  duration: {{ .Values.ca.duration }}
+  renewBefore: {{ .Values.ca.renewBefore }}
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: {{ .Values.ca.bootstrapIssuer }}
+    kind: ClusterIssuer
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: {{ include "zot-infra.caIssuerName" . }}
+spec:
+  ca:
+    secretName: {{ include "zot-infra.caSecretName" . }}

--- a/zot-oci-registry-in-cluster/templates/containerd-ds.yaml
+++ b/zot-oci-registry-in-cluster/templates/containerd-ds.yaml
@@ -1,0 +1,103 @@
+{{- /*
+  containerd DaemonSet — namespaces.certManager
+  Creates:
+    1. A ConfigMap containing the hosts.toml for the internal registry endpoint
+    2. A DaemonSet with an init container that writes hosts.toml and the CA cert
+       from the internal-ca Secret to every node's containerd certs directory
+  The CA cert is sourced directly from the Secret (caSecretName) — no manual
+  cert distribution is needed. Trigger a rollout after CA rotation.
+*/ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "zot-infra.dsCmName" . }}
+  namespace: {{ .Values.namespaces.certManager }}
+data:
+  hosts.toml: |
+    server = "https://{{ .Values.internalGateway.lbIP }}:{{ .Values.internalGateway.port }}"
+
+    [host."https://{{ .Values.internalGateway.lbIP }}:{{ .Values.internalGateway.port }}"]
+      capabilities = ["pull", "resolve"]
+      ca = ["/etc/containerd/certs.d/{{ .Values.internalGateway.lbIP }}:{{ .Values.internalGateway.port }}/ca.crt"]
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "zot-infra.dsName" . }}
+  namespace: {{ .Values.namespaces.certManager }}
+  labels:
+    app: {{ include "zot-infra.dsName" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "zot-infra.dsName" . }}
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: {{ include "zot-infra.dsName" . }}
+    spec:
+      priorityClassName: system-node-critical
+      tolerations:
+        - operator: Exists
+      initContainers:
+        - name: install-config
+          image: {{ .Values.daemonset.initImage }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              REGISTRY="{{ .Values.internalGateway.lbIP }}:{{ .Values.internalGateway.port }}"
+              CERTS_DIR="/host/etc/containerd/certs.d/${REGISTRY}"
+              echo "Creating registry config dir: ${CERTS_DIR}"
+              mkdir -p "${CERTS_DIR}"
+              echo "Writing hosts.toml"
+              cp /config/hosts.toml "${CERTS_DIR}/hosts.toml"
+              echo "Writing ca.crt from secret"
+              cp /ca/ca.crt "${CERTS_DIR}/ca.crt"
+              echo "Done."
+              cat "${CERTS_DIR}/hosts.toml"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: host-containerd-certs
+              mountPath: /host/etc/containerd/certs.d
+            - name: config
+              mountPath: /config
+              readOnly: true
+            - name: ca-secret
+              mountPath: /ca
+              readOnly: true
+      containers:
+        - name: pause
+          image: {{ .Values.daemonset.pauseImage }}
+          resources:
+            requests:
+              cpu: 1m
+              memory: 8Mi
+            limits:
+              cpu: 10m
+              memory: 16Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+      volumes:
+        - name: host-containerd-certs
+          hostPath:
+            path: /etc/containerd/certs.d
+            type: DirectoryOrCreate
+        - name: config
+          configMap:
+            name: {{ include "zot-infra.dsCmName" . }}
+        - name: ca-secret
+          secret:
+            secretName: {{ include "zot-infra.caSecretName" . }}
+            items:
+              - key: ca.crt
+                path: ca.crt

--- a/zot-oci-registry-in-cluster/templates/external-gateway-httproute.yaml
+++ b/zot-oci-registry-in-cluster/templates/external-gateway-httproute.yaml
@@ -1,0 +1,29 @@
+{{- /*
+  External Gateway HTTPRoute — namespaces.zot
+  Routes HTTPS traffic from the public Gateway to the zot backend Service.
+  The 1-hour timeouts are required for large OCI blob uploads.
+*/ -}}
+{{- $hostname := printf "registry.%s.coreweave.app" .Values.externalGateway.clusterOrgHostname }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "zot-infra.externalRouteName" . }}
+  namespace: {{ .Values.namespaces.zot }}
+spec:
+  parentRefs:
+    - name: {{ include "zot-infra.externalGwName" . }}
+      namespace: {{ .Values.namespaces.kgateway }}
+      sectionName: https
+  hostnames:
+    - {{ $hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      timeouts:
+        request: 3600s       # 1 hour — needed for large blob uploads
+        backendRequest: 3600s
+      backendRefs:
+        - name: {{ .Values.externalGateway.zotServiceName }}
+          port: {{ .Values.externalGateway.port }}

--- a/zot-oci-registry-in-cluster/templates/external-gateway.yaml
+++ b/zot-oci-registry-in-cluster/templates/external-gateway.yaml
@@ -20,6 +20,11 @@ spec:
       extraAnnotations:
         service.beta.kubernetes.io/external-hostname: {{ $hostname | quote }}
         service.beta.kubernetes.io/coreweave-load-balancer-type: public
+    {{- if .Values.externalGateway.nodeAffinity }}
+    podTemplate:
+      affinity:
+        nodeAffinity: {{ .Values.externalGateway.nodeAffinity | toYaml | nindent 10 }}
+    {{- end }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway

--- a/zot-oci-registry-in-cluster/templates/external-gateway.yaml
+++ b/zot-oci-registry-in-cluster/templates/external-gateway.yaml
@@ -1,0 +1,57 @@
+{{- /*
+  External Gateway — namespaces.kgateway
+  Creates:
+    1. A GatewayParameters resource that annotates the LB Service with the
+       public hostname and marks it as a CoreWeave public load balancer
+    2. A Gateway with the cert-manager cluster-issuer annotation so cert-manager
+       issues and renews the Let's Encrypt certificate automatically
+  The helm.sh/resource-policy: keep annotation prevents accidental deletion
+  of the Gateway since it is shared infrastructure.
+*/ -}}
+{{- $hostname := printf "registry.%s.coreweave.app" .Values.externalGateway.clusterOrgHostname }}
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: GatewayParameters
+metadata:
+  name: {{ include "zot-infra.externalGwParamsName" . }}
+  namespace: {{ .Values.namespaces.kgateway }}
+spec:
+  kube:
+    service:
+      extraAnnotations:
+        service.beta.kubernetes.io/external-hostname: {{ $hostname | quote }}
+        service.beta.kubernetes.io/coreweave-load-balancer-type: public
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ include "zot-infra.externalGwName" . }}
+  namespace: {{ .Values.namespaces.kgateway }}
+  annotations:
+    helm.sh/resource-policy: keep
+    cert-manager.io/cluster-issuer: {{ .Values.externalGateway.clusterIssuer }}
+spec:
+  gatewayClassName: kgateway
+  infrastructure:
+    parametersRef:
+      name: {{ include "zot-infra.externalGwParamsName" . }}
+      group: gateway.kgateway.dev
+      kind: GatewayParameters
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https
+      protocol: HTTPS
+      port: 443
+      hostname: {{ $hostname | quote }}
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: {{ include "zot-infra.externalCertSecretName" . }}
+            kind: Secret
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/zot-oci-registry-in-cluster/templates/internal-gateway-httproute.yaml
+++ b/zot-oci-registry-in-cluster/templates/internal-gateway-httproute.yaml
@@ -1,0 +1,25 @@
+{{- /*
+  Internal Gateway HTTPRoute — namespaces.zot
+  Routes all traffic entering the internal Gateway to the zot backend Service.
+*/ -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "zot-infra.internalRouteName" . }}
+  namespace: {{ .Values.namespaces.zot }}
+spec:
+  parentRefs:
+    - name: {{ include "zot-infra.internalGwName" . }}
+      namespace: {{ .Values.namespaces.kgateway }}
+      sectionName: https
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      timeouts:
+        request: 3600s       # 1 hour — needed for large blob uploads
+        backendRequest: 3600s
+      backendRefs:
+        - name: {{ .Values.internalGateway.zotServiceName }}
+          port: {{ .Values.internalGateway.port }}

--- a/zot-oci-registry-in-cluster/templates/internal-gateway.yaml
+++ b/zot-oci-registry-in-cluster/templates/internal-gateway.yaml
@@ -16,6 +16,11 @@ spec:
   kube:
     service:
       type: LoadBalancer
+    {{- if .Values.internalGateway.nodeAffinity }}
+    podTemplate:
+      affinity:
+        nodeAffinity: {{ .Values.internalGateway.nodeAffinity | toYaml | nindent 10 }}
+    {{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/zot-oci-registry-in-cluster/templates/internal-gateway.yaml
+++ b/zot-oci-registry-in-cluster/templates/internal-gateway.yaml
@@ -1,0 +1,70 @@
+{{- /*
+  Internal Gateway — namespaces.kgateway
+  Creates:
+    1. A GatewayParameters resource configuring a LoadBalancer Service
+    2. A cert-manager Certificate with an IP SAN matching the internal-lb VIP
+    3. A Gateway bound to the internal-lb VIP with TLS termination
+  The helm.sh/resource-policy: keep annotation prevents accidental deletion
+  of the Gateway since it is shared infrastructure.
+*/ -}}
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: GatewayParameters
+metadata:
+  name: {{ include "zot-infra.internalGwParamsName" . }}
+  namespace: {{ .Values.namespaces.kgateway }}
+spec:
+  kube:
+    service:
+      type: LoadBalancer
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "zot-infra.internalCertName" . }}
+  namespace: {{ .Values.namespaces.kgateway }}
+spec:
+  secretName: {{ include "zot-infra.internalCertSecretName" . }}
+  issuerRef:
+    name: {{ include "zot-infra.caIssuerName" . }}
+    kind: ClusterIssuer
+  duration: {{ .Values.internalGateway.duration }}
+  renewBefore: {{ .Values.internalGateway.renewBefore }}
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  ipAddresses:
+    - {{ .Values.internalGateway.lbIP }}
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ include "zot-infra.internalGwName" . }}
+  namespace: {{ .Values.namespaces.kgateway }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  gatewayClassName: kgateway
+  addresses:
+    - type: IPAddress
+      value: {{ .Values.internalGateway.lbIP | quote }}
+  infrastructure:
+    parametersRef:
+      name: {{ include "zot-infra.internalGwParamsName" . }}
+      group: gateway.kgateway.dev
+      kind: GatewayParameters
+  listeners:
+    - name: https
+      protocol: HTTPS
+      port: {{ .Values.internalGateway.port }}
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: {{ include "zot-infra.internalCertSecretName" . }}
+            kind: Secret
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/zot-oci-registry-in-cluster/templates/networkpolicy-external-gateway.yaml
+++ b/zot-oci-registry-in-cluster/templates/networkpolicy-external-gateway.yaml
@@ -1,0 +1,80 @@
+{{- if .Values.externalGateway.networkPolicy.enabled }}
+---
+# Deny all ingress to the external gateway pod by default
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "zot-infra.externalGwName" . }}-deny-all
+  namespace: {{ .Values.namespaces.kgateway }}
+  annotations:
+    helm.sh/resource-policy: keep
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: Helm
+spec:
+  podSelector:
+    matchLabels:
+      gateway.networking.k8s.io/gateway-name: {{ include "zot-infra.externalGwName" . }}
+  policyTypes:
+  - Ingress
+---
+# Allow port 80 from anywhere.
+# Required for Let's Encrypt HTTP-01 challenge and HTTP -> HTTPS redirects.
+# Port 80 carries no sensitive data.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "zot-infra.externalGwName" . }}-allow-http
+  namespace: {{ .Values.namespaces.kgateway }}
+  annotations:
+    helm.sh/resource-policy: keep
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: Helm
+spec:
+  podSelector:
+    matchLabels:
+      gateway.networking.k8s.io/gateway-name: {{ include "zot-infra.externalGwName" . }}
+  policyTypes:
+  - Ingress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 80
+---
+# Allow port 443 (HTTPS) only from trusted CIDRs
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "zot-infra.externalGwName" . }}-allow-https-cidrs
+  namespace: {{ .Values.namespaces.kgateway }}
+  annotations:
+    helm.sh/resource-policy: keep
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: Helm
+spec:
+  podSelector:
+    matchLabels:
+      gateway.networking.k8s.io/gateway-name: {{ include "zot-infra.externalGwName" . }}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    {{- range .Values.externalGateway.networkPolicy.allowedCIDRs }}
+    - ipBlock:
+        cidr: {{ .cidr }}
+        {{- if .except }}
+        except:
+        {{- range .except }}
+        - {{ . }}
+        {{- end }}
+        {{- end }}
+    {{- end }}
+    ports:
+    - protocol: TCP
+      port: 443
+{{- end }}

--- a/zot-oci-registry-in-cluster/values.yaml
+++ b/zot-oci-registry-in-cluster/values.yaml
@@ -55,6 +55,20 @@ internalGateway:
   duration: 8760h   # 1 year
   renewBefore: 720h # 30 days
 
+  # Node affinity for the gateway proxy pod.
+  # Uses preferredDuringSchedulingIgnoredDuringExecution so the pod is steered
+  # toward CPU nodes but will still schedule elsewhere if none are available.
+  # Set nodeAffinity: {} to disable.
+  nodeAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+            - key: node.coreweave.cloud/class
+              operator: In
+              values:
+                - cpu
+
 # -----------------------------------------------------------------------------
 # externalGateway — Let's Encrypt TLS + public hostname
 # Exposes zot on a public hostname for docker push / Web UI access.
@@ -74,6 +88,21 @@ externalGateway:
 
   # Port the zot backend service listens on
   port: 5000
+
+  # Node affinity for the gateway proxy pod.
+  # Uses preferredDuringSchedulingIgnoredDuringExecution so the pod is steered
+  # toward CPU nodes but will still schedule elsewhere if none are available.
+  # Set nodeAffinity: {} to disable.
+  nodeAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+            - key: node.coreweave.cloud/class
+              operator: In
+              values:
+                - cpu
+
   networkPolicy:
     enabled: false
     allowedCIDRs:

--- a/zot-oci-registry-in-cluster/values.yaml
+++ b/zot-oci-registry-in-cluster/values.yaml
@@ -1,0 +1,95 @@
+# =============================================================================
+# zot-infra values
+# All configurable values are here. Resource names are NOT configured here —
+# they are derived from the Helm release name in templates/_helpers.tpl.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# namespaces — installation namespaces for each upstream component
+# Change these if your cluster uses non-default namespace names.
+# -----------------------------------------------------------------------------
+namespaces:
+  # Namespace where cert-manager is installed
+  # The internal CA Certificate is created here so cert-manager can read it
+  certManager: kube-system
+
+  # Namespace where kgateway is installed
+  # Gateway, GatewayParameters, and the internal Certificate live here
+  kgateway: kgateway-system
+
+  # Namespace where zot is installed
+  # HTTPRoutes live here so they resolve the zot ClusterIP Service
+  zot: zot-registry
+
+# -----------------------------------------------------------------------------
+# ca — Internal CA bootstrap
+# Creates a self-signed CA Certificate and the ClusterIssuer backed by it.
+# Wait for ClusterIssuer READY=True before the internal Gateway cert can issue.
+# -----------------------------------------------------------------------------
+ca:
+  # Pre-existing ClusterIssuer used to self-sign the CA certificate
+  # Must already exist (provided by the coreweave/cert-manager Helm chart)
+  bootstrapIssuer: selfsigned-cluster-issuer
+  # Validity duration of the CA certificate
+  duration: 87600h   # 10 years
+  renewBefore: 720h  # 30 days
+
+# -----------------------------------------------------------------------------
+# internalGateway — Private CA TLS + internal-lb VIP
+# Exposes zot on a fixed internal LoadBalancer IP for in-cluster containerd pulls.
+# TLS is terminated at the Gateway using a cert with an IP SAN.
+# Resources land in namespaces.kgateway (Gateway/Cert) and namespaces.zot (HTTPRoute).
+# -----------------------------------------------------------------------------
+internalGateway:
+  # Fixed IP for the internal LoadBalancer Service.
+  # Must be an unused IP from the cluster's internal-lb CIDR pool.
+  lbIP: ""  # e.g. 10.16.12.10
+
+  # Port the internal registry listens on
+  port: 5000
+
+  # Kubernetes Service name for the zot backend (created by the zot Helm chart)
+  zotServiceName: zot
+
+  # Validity duration of the internal leaf certificate
+  duration: 8760h   # 1 year
+  renewBefore: 720h # 30 days
+
+# -----------------------------------------------------------------------------
+# externalGateway — Let's Encrypt TLS + public hostname
+# Exposes zot on a public hostname for docker push / Web UI access.
+# cert-manager handles certificate issuance via the Gateway annotation.
+# Resources land in namespaces.kgateway (Gateway) and namespaces.zot (HTTPRoute).
+# -----------------------------------------------------------------------------
+externalGateway:
+  # Org ID and cluster name segment used to build the public FQDN.
+  # The hostname will be rendered as: registry.<clusterOrgHostname>.coreweave.app
+  clusterOrgHostname: ""  # e.g. cwxxx-cluster03
+
+  # ClusterIssuer used for Let's Encrypt (must already exist)
+  clusterIssuer: letsencrypt-prod
+
+  # Kubernetes Service name for the zot backend (created by the zot Helm chart)
+  zotServiceName: zot
+
+  # Port the zot backend service listens on
+  port: 5000
+  networkPolicy:
+    enabled: false
+    allowedCIDRs:
+      - cidr: 192.168.0.0/16        # on-prem / office range
+      - cidr: 203.0.113.10/32       # specific external IP — replace with your IPs
+        # except:                   # optional: exclude sub-ranges within a CIDR
+        #   - 203.0.113.5/32  
+
+# -----------------------------------------------------------------------------
+# daemonset — containerd node configuration
+# Writes hosts.toml and the internal CA cert to every node so containerd can
+# pull images from the internal registry over TLS without a node restart.
+# -----------------------------------------------------------------------------
+daemonset:
+  # Init container image used to write files to the host filesystem
+  initImage: busybox:1.36
+
+  # Pause container image (keeps the pod alive after init completes)
+  pauseImage: registry.k8s.io/pause:3.10


### PR DESCRIPTION
## Summary

- Adds the `zot-oci-registry-in-cluster` Helm chart (`zot-infra`) for deploying a zot OCI
  registry on Kubernetes with TLS termination via kgateway, internal CA bootstrap, and
  S3-compatible backend storage (CAIOS or LOTA)
- Adds deployment documentation covering external/internal gateways, containerd DaemonSet
  node config, imagePullSecret setup, and ECR mirroring via skopeo
- Adds benchmark reports comparing zot registry performance against DockerHub and with/without
  LOTA as the storage backend, covering both `zb` load tests and real `enroot import` workloads

## Benchmark Findings

Two benchmark tools were used: `zb` (zot's own load testing tool) and `enroot import`
(NVIDIA's HPC container runtime), with a DockerHub baseline included for the enroot runs.

### zb results

`zb` generates unique objects per run, so LOTA's cache is perpetually cold for all pull
operations — every read proxies through LOTA to CAIOS, adding an extra network hop.

Push operations improved consistently with LOTA across all sizes. This is expected: writes
are acknowledged by the LOTA DaemonSet process running locally on the node, reducing
observed write latency before the data is fully persisted to CAIOS.

Cold pull behavior was asymmetric by object size:
- **Small objects (1MB, 10MB):** Still faster with LOTA, even cold. LOTA maintains
  persistent connections to CAIOS, absorbing connection setup overhead.
- **Large objects (100MB):** Slower with LOTA when cold. At that size the connection reuse
  benefit is negligible, and buffering 100MB through the proxy layer outweighs any gain.

### enroot results (DockerHub vs. Zot with/without LOTA)

| Source | Cold import | Download phase | vs. DockerHub |
|---|---|---|---|
| DockerHub | 2m 15.6s | ~62s | baseline |
| Zot — Without LOTA | 1m 47.8s | ~35s | **-27.8s / 20.5% faster** |
| Zot — With LOTA | 1m 51.5s | ~35s | **-24.1s / 17.8% faster** |

The in-cluster zot registry is the primary win — it nearly halves the layer download time
by keeping images on-cluster and avoiding public internet latency. LOTA vs. no LOTA is a
3.7s difference on a ~108s operation dominated by CPU-bound squashfs compression.

### LOTA Benefit Assessment

LOTA provides limited benefit in practice for container image workflows:

- **Kubernetes (containerd):** After the first cold pull, containerd and kubelet cache image
  layers on the node — subsequent pod starts never hit the registry. LOTA also retains a
  cached copy, meaning the image is stored twice on the same node with no access advantage.

- **Enroot (SLURM):** The `.sqsh` file produced by `enroot import` is written to an
  NFS-mounted shared folder accessible to all users and nodes. Once any user imports an
  image, all others reuse the same `.sqsh` file directly — bypassing both enroot's layer
  cache and LOTA's node-local cache entirely. There is no re-import scenario in practice
  where LOTA would provide benefit.

- **LOTA is a per-node DaemonSet.** Its cache does not carry across nodes, further limiting
  utility in multi-node SLURM environments.

The clearest remaining use case for LOTA with zot would be push-heavy workflows, where its
write-acknowledgment behavior consistently reduces push latency across all object sizes.

## Test plan

- [ ] Review `zot-infra/values.yaml` placeholders and fill in environment-specific values before install
- [ ] Verify `ClusterIssuers` and kgateway are installed before running `helm upgrade -i zot-infra`
- [ ] Validate containerd DaemonSet wrote certs to nodes via `cwic node shell`
- [ ] Run `zb-bencharmarking.yaml` Job to reproduce benchmark results