### PR TITLE
feat(secrets-management): add cloud-kms references for aws and gcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # reference-architecture
 Reference architectures for various use cases at CoreWeave.
+
+## Additional Reference Areas
+
+- [secrets-management](./secrets-management/README.md): Cloud KMS-backed secret manager patterns for Kubernetes workloads.

--- a/secrets-management/README.md
+++ b/secrets-management/README.md
@@ -1,0 +1,52 @@
+# Secrets Management Reference Architectures
+
+This directory contains end-to-end reference architectures for managing application secrets on CoreWeave Kubernetes Service (CKS).
+
+All references use External Secrets Operator (ESO) as the Kubernetes abstraction layer and expose the same runtime secret contract:
+
+- `DB_USERNAME`
+- `DB_PASSWORD`
+- `API_TOKEN`
+
+## Architectures
+
+| Architecture | Backend | Auth Model | Path |
+| --- | --- | --- | --- |
+| Cloud KMS (AWS) | AWS Secrets Manager encrypted by AWS KMS | OIDC federation from CKS -> AWS STS short-lived role creds | [`cloud-kms/aws-kms/`](./cloud-kms/aws-kms/README.md) |
+| Cloud KMS (GCP) | Google Secret Manager encrypted by Cloud KMS (CMEK) | OIDC federation from CKS -> GCP Workload Identity short-lived creds | [`cloud-kms/gcp-kms/`](./cloud-kms/gcp-kms/README.md) |
+
+## Shared Prerequisites
+
+- A running CKS cluster.
+- `kubectl`, `helm`, and provider CLIs (`aws`, `gcloud`) installed as needed.
+- External Secrets Operator installed once per cluster:
+
+```bash
+helm repo add external-secrets https://charts.external-secrets.io
+helm repo update
+helm install external-secrets external-secrets/external-secrets \
+  --namespace external-secrets \
+  --create-namespace
+kubectl rollout status deployment/external-secrets -n external-secrets
+```
+
+## Validation Pattern (All Architectures)
+
+1. Apply manifests for the selected architecture.
+2. Confirm ESO reconciles:
+
+```bash
+kubectl get externalsecret -A
+```
+
+3. Confirm generated Kubernetes Secret exists:
+
+```bash
+kubectl get secret app-runtime-secrets -n <namespace>
+```
+
+4. Confirm workload can read synced values:
+
+```bash
+kubectl logs deployment/secrets-demo -n <namespace>
+```

--- a/secrets-management/README.md
+++ b/secrets-management/README.md
@@ -17,9 +17,11 @@ All references use External Secrets Operator (ESO) as the Kubernetes abstraction
 
 ## Shared Prerequisites
 
-- A running CKS cluster.
+- CoreWeave account permissions to create a VPC and CKS cluster.
+- A CoreWeave API token exported as `TF_VAR_coreweave_api_token`.
 - `kubectl`, `helm`, and provider CLIs (`aws`, `gcloud`) installed as needed.
-- External Secrets Operator installed once per cluster:
+
+After Terraform creates the CKS cluster and you download kubeconfig, install External Secrets Operator once per cluster:
 
 ```bash
 helm repo add external-secrets https://charts.external-secrets.io
@@ -32,20 +34,24 @@ kubectl rollout status deployment/external-secrets -n external-secrets
 
 ## Validation Pattern (All Architectures)
 
-1. Apply manifests for the selected architecture.
-2. Confirm ESO reconciles:
+1. Apply Terraform for the selected architecture. Each example creates its own VPC, CKS cluster, KMS key, and provider secret backend.
+2. Download kubeconfig for the new CKS cluster from CoreWeave Console.
+3. Ensure the cluster has schedulable node capacity before installing workloads.
+4. Install ESO on that cluster.
+5. Apply manifests for the selected architecture.
+6. Confirm ESO reconciles:
 
 ```bash
 kubectl get externalsecret -A
 ```
 
-3. Confirm generated Kubernetes Secret exists:
+7. Confirm generated Kubernetes Secret exists:
 
 ```bash
 kubectl get secret app-runtime-secrets -n <namespace>
 ```
 
-4. Confirm workload can read synced values:
+8. Confirm workload can read synced values:
 
 ```bash
 kubectl logs deployment/secrets-demo -n <namespace>

--- a/secrets-management/cloud-kms/README.md
+++ b/secrets-management/cloud-kms/README.md
@@ -12,6 +12,7 @@ Both references use External Secrets Operator (ESO) to sync provider secrets int
 - No static AWS access keys or GCP service account key files are required for ESO.
 - CKS workload identity is federated into each cloud provider for short-lived credentials.
 - Secret values remain in provider-managed secret managers, encrypted by KMS keys.
+- Terraform can source the CKS OIDC issuer URL automatically from this repo's CKS stack output (`cks_service_account_oidc_issuer_url`).
 
 ## Provider References
 

--- a/secrets-management/cloud-kms/README.md
+++ b/secrets-management/cloud-kms/README.md
@@ -1,0 +1,19 @@
+# Cloud KMS Secret References
+
+These references use cloud-native secret managers with customer-managed encryption keys:
+
+- AWS: AWS Secrets Manager + AWS KMS
+- GCP: Secret Manager + Cloud KMS (CMEK)
+
+Both references use External Secrets Operator (ESO) to sync provider secrets into Kubernetes `Secret` objects for workloads.
+
+## Key Security Properties
+
+- No static AWS access keys or GCP service account key files are required for ESO.
+- CKS workload identity is federated into each cloud provider for short-lived credentials.
+- Secret values remain in provider-managed secret managers, encrypted by KMS keys.
+
+## Provider References
+
+- AWS: [`aws-kms/`](./aws-kms/README.md)
+- GCP: [`gcp-kms/`](./gcp-kms/README.md)

--- a/secrets-management/cloud-kms/README.md
+++ b/secrets-management/cloud-kms/README.md
@@ -12,7 +12,7 @@ Both references use External Secrets Operator (ESO) to sync provider secrets int
 - No static AWS access keys or GCP service account key files are required for ESO.
 - CKS workload identity is federated into each cloud provider for short-lived credentials.
 - Secret values remain in provider-managed secret managers, encrypted by KMS keys.
-- Terraform can source the CKS OIDC issuer URL automatically from this repo's CKS stack output (`cks_service_account_oidc_issuer_url`).
+- Each provider example creates its own CoreWeave VPC and CKS cluster, then uses that cluster's service-account OIDC issuer URL for cloud federation.
 
 ## Provider References
 

--- a/secrets-management/cloud-kms/aws-kms/.gitignore
+++ b/secrets-management/cloud-kms/aws-kms/.gitignore
@@ -1,0 +1,3 @@
+# Local-only files for following the tutorial:
+.envrc
+kubeconfig

--- a/secrets-management/cloud-kms/aws-kms/README.md
+++ b/secrets-management/cloud-kms/aws-kms/README.md
@@ -1,0 +1,97 @@
+# AWS KMS + Secrets Manager Reference
+
+This reference uses AWS Secrets Manager for secret storage, AWS KMS for encryption at rest, and External Secrets Operator (ESO) for Kubernetes sync.
+
+## Architecture
+
+1. CKS workload identity (service account token) is federated to AWS via IAM OIDC provider.
+2. ESO assumes an AWS IAM role using short-lived web identity credentials.
+3. ESO reads secrets from AWS Secrets Manager (encrypted by a customer-managed KMS key).
+4. ESO syncs secrets into Kubernetes `app-runtime-secrets`.
+
+No static AWS access key or secret key is required.
+
+## Prerequisites
+
+- CKS cluster + ESO installed.
+- AWS account with permissions to create:
+  - IAM role/policy
+  - KMS key
+  - Secrets Manager secrets
+- CKS OIDC issuer URL available from cluster details.
+- IAM OIDC provider configured in AWS for the CKS issuer URL.
+- Terraform installed.
+
+## Provision AWS Resources
+
+From this directory:
+
+```bash
+cd terraform
+cp terraform.tfvars.example terraform.tfvars
+```
+
+Set values in `terraform.tfvars`:
+- `oidc_issuer_url`
+- `oidc_provider_arn`
+- `secret_values` (bootstrap values)
+
+Then apply:
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+Capture outputs:
+
+```bash
+terraform output
+```
+
+You need:
+- `eso_role_arn`
+- `secret_names`
+
+## Configure and Apply Manifests
+
+1. Update:
+- `manifests/20-secret-store.yaml`
+  - `region`
+  - `role` (use `eso_role_arn`)
+- If Terraform defaults were changed, update secret names in `manifests/30-external-secret.yaml`.
+
+2. Apply:
+
+```bash
+kubectl apply -f manifests/00-namespace.yaml
+kubectl apply -f manifests/10-service-account.yaml
+kubectl apply -f manifests/20-secret-store.yaml
+kubectl apply -f manifests/30-external-secret.yaml
+kubectl apply -f manifests/40-demo-app.yaml
+```
+
+## Verify
+
+```bash
+kubectl get secretstore,externalsecret -n secrets-aws
+kubectl get secret app-runtime-secrets -n secrets-aws
+kubectl logs deployment/secrets-demo -n secrets-aws
+```
+
+## Rotation Test
+
+Rotate a secret in AWS:
+
+```bash
+aws secretsmanager put-secret-value \
+  --secret-id ra-demo/db-password \
+  --secret-string "rotated-password-$(date +%s)"
+```
+
+Wait for ESO refresh (1m), then verify the Kubernetes Secret updated:
+
+```bash
+kubectl get secret app-runtime-secrets -n secrets-aws -o yaml
+```

--- a/secrets-management/cloud-kms/aws-kms/README.md
+++ b/secrets-management/cloud-kms/aws-kms/README.md
@@ -16,10 +16,10 @@ No static AWS access key or secret key is required.
 - CKS cluster + ESO installed.
 - AWS account with permissions to create:
   - IAM role/policy
+  - IAM OIDC provider (if `create_oidc_provider=true`)
   - KMS key
   - Secrets Manager secrets
-- CKS OIDC issuer URL available from cluster details.
-- IAM OIDC provider configured in AWS for the CKS issuer URL.
+- (Recommended) CKS provisioned with this repository's Terraform stack so `cks_service_account_oidc_issuer_url` is available as an output.
 - Terraform installed.
 
 ## Provision AWS Resources
@@ -32,9 +32,16 @@ cp terraform.tfvars.example terraform.tfvars
 ```
 
 Set values in `terraform.tfvars`:
-- `oidc_issuer_url`
-- `oidc_provider_arn`
+- `cks_remote_state_*` (recommended) to auto-read `cks_service_account_oidc_issuer_url` from the CKS Terraform state.
 - `secret_values` (bootstrap values)
+
+If you cannot use `terraform_remote_state`, set:
+- `oidc_issuer_url` directly.
+
+By default, this stack creates an AWS IAM OIDC provider from the effective issuer URL (`create_oidc_provider=true`).
+If your organization manages that provider elsewhere, set:
+- `create_oidc_provider = false`
+- `oidc_provider_arn = <existing-provider-arn>`
 
 Then apply:
 
@@ -53,6 +60,8 @@ terraform output
 You need:
 - `eso_role_arn`
 - `secret_names`
+- `effective_oidc_issuer_url`
+- `effective_oidc_provider_arn`
 
 ## Configure and Apply Manifests
 

--- a/secrets-management/cloud-kms/aws-kms/README.md
+++ b/secrets-management/cloud-kms/aws-kms/README.md
@@ -22,6 +22,8 @@ No static AWS access key or secret key is required.
 - (Recommended) CKS provisioned with this repository's Terraform stack so `cks_service_account_oidc_issuer_url` is available as an output.
 - Terraform installed.
 
+`cks_service_account_oidc_issuer_url` comes from the read-only `service_account_oidc_issuer_url` field on `coreweave_cks_cluster`.
+
 ## Provision AWS Resources
 
 From this directory:

--- a/secrets-management/cloud-kms/aws-kms/README.md
+++ b/secrets-management/cloud-kms/aws-kms/README.md
@@ -1,99 +1,123 @@
-# AWS KMS + Secrets Manager Reference
+# AWS KMS + Secrets Manager Tutorial
 
-This reference uses AWS Secrets Manager for secret storage, AWS KMS for encryption at rest, and External Secrets Operator (ESO) for Kubernetes sync.
-
-## Architecture
-
-1. CKS workload identity (service account token) is federated to AWS via IAM OIDC provider.
-2. ESO assumes an AWS IAM role using short-lived web identity credentials.
-3. ESO reads secrets from AWS Secrets Manager (encrypted by a customer-managed KMS key).
-4. ESO syncs secrets into Kubernetes `app-runtime-secrets`.
-
-No static AWS access key or secret key is required.
+This tutorial provisions a disposable CoreWeave VPC and CKS cluster, creates AWS Secrets Manager secrets encrypted with AWS KMS, and verifies that External Secrets Operator syncs them into Kubernetes.
 
 ## Prerequisites
 
-- CKS cluster + ESO installed.
-- AWS account with permissions to create:
-  - IAM role/policy
-  - IAM OIDC provider (if `create_oidc_provider=true`)
-  - KMS key
-  - Secrets Manager secrets
-- (Recommended) CKS provisioned with this repository's Terraform stack so `cks_service_account_oidc_issuer_url` is available as an output.
-- Terraform installed.
+- CoreWeave account permissions to create a VPC and CKS cluster.
+- A CoreWeave API token exported as `TF_VAR_coreweave_api_token`.
+- AWS credentials available to Terraform, for example through `AWS_PROFILE`, with permissions to create IAM roles and policies, an IAM OIDC provider, KMS keys, and Secrets Manager secrets.
+- Terraform `>= 1.5`, `kubectl`, `helm`, and `aws`.
+- Access to CoreWeave Console to download kubeconfig for the new CKS cluster.
+- Schedulable CKS node capacity for ESO and the demo app. If the cluster does not get capacity automatically, create a NodePool after the cluster is ready.
 
-`cks_service_account_oidc_issuer_url` comes from the read-only `service_account_oidc_issuer_url` field on `coreweave_cks_cluster`.
-
-## Provision AWS Resources
-
-From this directory:
+## 1. Configure Terraform
 
 ```bash
 cd terraform
 cp terraform.tfvars.example terraform.tfvars
 ```
 
-Set values in `terraform.tfvars`:
-- `cks_remote_state_*` (recommended) to auto-read `cks_service_account_oidc_issuer_url` from the CKS Terraform state.
-- `secret_values` (bootstrap values)
+Edit `terraform.tfvars`:
 
-If you cannot use `terraform_remote_state`, set:
-- `oidc_issuer_url` directly.
+- Set `zone`, `vpc_name`, and `cluster_name`.
+- Set `aws_region`.
+- Replace `secret_values`.
+- Keep `create_oidc_provider = true` unless your AWS account already has an IAM OIDC provider for this CKS issuer.
 
-By default, this stack creates an AWS IAM OIDC provider from the effective issuer URL (`create_oidc_provider=true`).
-If your organization manages that provider elsewhere, set:
-- `create_oidc_provider = false`
-- `oidc_provider_arn = <existing-provider-arn>`
+Set credentials:
 
-Then apply:
+```bash
+export TF_VAR_coreweave_api_token="<COREWEAVE_API_TOKEN>"
+export AWS_PROFILE="<AWS_PROFILE>"
+```
+
+## 2. Provision
 
 ```bash
 terraform init
 terraform plan
 terraform apply
-```
-
-Capture outputs:
-
-```bash
 terraform output
 ```
 
-You need:
+Record these outputs:
+
+- `cks_cluster_name`
 - `eso_role_arn`
 - `secret_names`
-- `effective_oidc_issuer_url`
-- `effective_oidc_provider_arn`
 
-## Configure and Apply Manifests
+## 3. Connect To CKS
 
-1. Update:
-- `manifests/20-secret-store.yaml`
-  - `region`
-  - `role` (use `eso_role_arn`)
-- If Terraform defaults were changed, update secret names in `manifests/30-external-secret.yaml`.
-
-2. Apply:
+Download kubeconfig for `cks_cluster_name` from CoreWeave Console, then point `kubectl` at it:
 
 ```bash
-kubectl apply -f manifests/00-namespace.yaml
-kubectl apply -f manifests/10-service-account.yaml
-kubectl apply -f manifests/20-secret-store.yaml
-kubectl apply -f manifests/30-external-secret.yaml
-kubectl apply -f manifests/40-demo-app.yaml
+export KUBECONFIG="/path/to/downloaded/kubeconfig"
+kubectl get nodes
 ```
 
-## Verify
+If there are no schedulable nodes, apply the example CPU NodePool before continuing:
+
+```bash
+kubectl apply -f ../manifests/cpu-nodepool.yaml
+kubectl get nodepool cpu
+kubectl wait --for=condition=Ready nodes --all --timeout=10m
+```
+
+Edit `manifests/cpu-nodepool.yaml` if you need a different `instanceType` or `targetNodes`.
+
+## 4. Install ESO
+
+```bash
+helm repo add external-secrets https://charts.external-secrets.io
+helm repo update
+helm install external-secrets external-secrets/external-secrets \
+  --namespace external-secrets \
+  --create-namespace
+kubectl rollout status deployment/external-secrets -n external-secrets
+```
+
+## 5. Update Manifests
+
+Edit `../manifests/10-service-account.yaml`:
+
+- Set `metadata.annotations["eks.amazonaws.com/role-arn"]` to `eso_role_arn`.
+
+Edit `../manifests/20-secret-store.yaml`:
+
+- Set `spec.provider.aws.region` to `aws_region`.
+
+If you changed `secret_name_prefix`, update remote keys in `../manifests/30-external-secret.yaml` to match `secret_names`.
+
+## 6. Apply Manifests
+
+```bash
+kubectl apply -f ../manifests/00-namespace.yaml
+kubectl apply -f ../manifests/10-service-account.yaml
+kubectl apply -f ../manifests/20-secret-store.yaml
+kubectl apply -f ../manifests/30-external-secret.yaml
+kubectl apply -f ../manifests/40-demo-app.yaml
+```
+
+## 7. Verify
 
 ```bash
 kubectl get secretstore,externalsecret -n secrets-aws
+kubectl describe externalsecret app-secrets -n secrets-aws
 kubectl get secret app-runtime-secrets -n secrets-aws
+kubectl rollout status deployment/secrets-demo -n secrets-aws
 kubectl logs deployment/secrets-demo -n secrets-aws
 ```
 
-## Rotation Test
+The demo logs should show:
 
-Rotate a secret in AWS:
+```text
+DB_USERNAME loaded
+DB_PASSWORD loaded
+API_TOKEN loaded
+```
+
+## 8. Test Rotation
 
 ```bash
 aws secretsmanager put-secret-value \
@@ -101,8 +125,19 @@ aws secretsmanager put-secret-value \
   --secret-string "rotated-password-$(date +%s)"
 ```
 
-Wait for ESO refresh (1m), then verify the Kubernetes Secret updated:
+Wait at least one ESO refresh interval, then verify the Kubernetes Secret changed:
 
 ```bash
 kubectl get secret app-runtime-secrets -n secrets-aws -o yaml
+```
+
+## 9. Clean Up
+
+```bash
+kubectl delete -f ../manifests/40-demo-app.yaml --ignore-not-found
+kubectl delete -f ../manifests/30-external-secret.yaml --ignore-not-found
+kubectl delete -f ../manifests/20-secret-store.yaml --ignore-not-found
+kubectl delete -f ../manifests/10-service-account.yaml --ignore-not-found
+kubectl delete -f ../manifests/00-namespace.yaml --ignore-not-found
+terraform destroy
 ```

--- a/secrets-management/cloud-kms/aws-kms/env.example
+++ b/secrets-management/cloud-kms/aws-kms/env.example
@@ -1,0 +1,6 @@
+AWS_REGION=us-east-1
+AWS_OIDC_ISSUER_URL=https://oidc.cks.coreweave.com/id/replace-me
+AWS_OIDC_PROVIDER_ARN=arn:aws:iam::123456789012:oidc-provider/oidc.cks.coreweave.com/id/replace-me
+AWS_SECRET_ROLE_ARN=arn:aws:iam::123456789012:role/ra-eso-aws-secrets-reader
+NAMESPACE=secrets-aws
+SERVICE_ACCOUNT_NAME=eso-aws-auth

--- a/secrets-management/cloud-kms/aws-kms/env.example
+++ b/secrets-management/cloud-kms/aws-kms/env.example
@@ -1,6 +1,12 @@
 AWS_REGION=us-east-1
+
+# Recommended: derive issuer URL from CKS terraform output (cks_service_account_oidc_issuer_url).
+CKS_TFSTATE_PATH=../../../../terraform/terraform.tfstate
+
+# Optional manual overrides if remote state is not used:
 AWS_OIDC_ISSUER_URL=https://oidc.cks.coreweave.com/id/replace-me
 AWS_OIDC_PROVIDER_ARN=arn:aws:iam::123456789012:oidc-provider/oidc.cks.coreweave.com/id/replace-me
+
 AWS_SECRET_ROLE_ARN=arn:aws:iam::123456789012:role/ra-eso-aws-secrets-reader
 NAMESPACE=secrets-aws
 SERVICE_ACCOUNT_NAME=eso-aws-auth

--- a/secrets-management/cloud-kms/aws-kms/env.example
+++ b/secrets-management/cloud-kms/aws-kms/env.example
@@ -1,12 +1,20 @@
+COREWEAVE_ZONE=US-EAST-04A
+COREWEAVE_VPC_NAME=ra-secrets-aws-vpc
+CKS_CLUSTER_NAME=ra-secrets-aws-cks
+CKS_KUBERNETES_VERSION=v1.35
+
+# AWS_REGION is used by both Terraform (via the aws_region tfvar) and the aws CLI.
 AWS_REGION=us-east-1
 
-# Recommended: derive issuer URL from CKS terraform output (cks_service_account_oidc_issuer_url).
-CKS_TFSTATE_PATH=../../../../terraform/terraform.tfstate
+# Terraform creates the CKS cluster and uses its service-account issuer URL directly.
+# Set TF_VAR_coreweave_api_token separately; do not store it in this file.
 
-# Optional manual overrides if remote state is not used:
-AWS_OIDC_ISSUER_URL=https://oidc.cks.coreweave.com/id/replace-me
+# Optional only when create_oidc_provider=false.
 AWS_OIDC_PROVIDER_ARN=arn:aws:iam::123456789012:oidc-provider/oidc.cks.coreweave.com/id/replace-me
 
 AWS_SECRET_ROLE_ARN=arn:aws:iam::123456789012:role/ra-eso-aws-secrets-reader
 NAMESPACE=secrets-aws
 SERVICE_ACCOUNT_NAME=eso-aws-auth
+
+# Path to the kubeconfig downloaded from CoreWeave Console for the CKS cluster.
+KUBECONFIG=/path/to/downloaded/kubeconfig

--- a/secrets-management/cloud-kms/aws-kms/manifests/00-namespace.yaml
+++ b/secrets-management/cloud-kms/aws-kms/manifests/00-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: secrets-aws

--- a/secrets-management/cloud-kms/aws-kms/manifests/10-service-account.yaml
+++ b/secrets-management/cloud-kms/aws-kms/manifests/10-service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso-aws-auth
+  namespace: secrets-aws

--- a/secrets-management/cloud-kms/aws-kms/manifests/10-service-account.yaml
+++ b/secrets-management/cloud-kms/aws-kms/manifests/10-service-account.yaml
@@ -3,3 +3,6 @@ kind: ServiceAccount
 metadata:
   name: eso-aws-auth
   namespace: secrets-aws
+  annotations:
+    # Use Terraform output: eso_role_arn
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/ra-eso-aws-secrets-reader

--- a/secrets-management/cloud-kms/aws-kms/manifests/20-secret-store.yaml
+++ b/secrets-management/cloud-kms/aws-kms/manifests/20-secret-store.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: aws-secretsmanager-store
+  namespace: secrets-aws
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: us-east-1
+      # Use Terraform output: eso_role_arn
+      role: arn:aws:iam::123456789012:role/ra-eso-aws-secrets-reader
+      auth:
+        jwt:
+          serviceAccountRef:
+            name: eso-aws-auth

--- a/secrets-management/cloud-kms/aws-kms/manifests/20-secret-store.yaml
+++ b/secrets-management/cloud-kms/aws-kms/manifests/20-secret-store.yaml
@@ -8,8 +8,6 @@ spec:
     aws:
       service: SecretsManager
       region: us-east-1
-      # Use Terraform output: eso_role_arn
-      role: arn:aws:iam::123456789012:role/ra-eso-aws-secrets-reader
       auth:
         jwt:
           serviceAccountRef:

--- a/secrets-management/cloud-kms/aws-kms/manifests/30-external-secret.yaml
+++ b/secrets-management/cloud-kms/aws-kms/manifests/30-external-secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: app-secrets
+  namespace: secrets-aws
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: aws-secretsmanager-store
+    kind: SecretStore
+  target:
+    name: app-runtime-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: DB_USERNAME
+      remoteRef:
+        key: ra-demo/db-username
+    - secretKey: DB_PASSWORD
+      remoteRef:
+        key: ra-demo/db-password
+    - secretKey: API_TOKEN
+      remoteRef:
+        key: ra-demo/api-token

--- a/secrets-management/cloud-kms/aws-kms/manifests/40-demo-app.yaml
+++ b/secrets-management/cloud-kms/aws-kms/manifests/40-demo-app.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: secrets-demo
+  namespace: secrets-aws
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: secrets-demo
+  template:
+    metadata:
+      labels:
+        app: secrets-demo
+    spec:
+      containers:
+        - name: app
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              while true; do
+                date
+                [ -n "$DB_USERNAME" ] && echo "DB_USERNAME loaded"
+                [ -n "$DB_PASSWORD" ] && echo "DB_PASSWORD loaded"
+                [ -n "$API_TOKEN" ] && echo "API_TOKEN loaded"
+                sleep 30
+              done
+          envFrom:
+            - secretRef:
+                name: app-runtime-secrets

--- a/secrets-management/cloud-kms/aws-kms/manifests/cpu-nodepool.yaml
+++ b/secrets-management/cloud-kms/aws-kms/manifests/cpu-nodepool.yaml
@@ -1,0 +1,9 @@
+apiVersion: compute.coreweave.com/v1alpha1
+kind: NodePool
+metadata:
+  name: cpu
+spec:
+  instanceType: cd-gp-i64-erapids
+  targetNodes: 1
+  nodeConfigurationUpdateStrategy:
+    type: OnSpecUpdate

--- a/secrets-management/cloud-kms/aws-kms/terraform/.gitignore
+++ b/secrets-management/cloud-kms/aws-kms/terraform/.gitignore
@@ -1,0 +1,5 @@
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+terraform.tfvars

--- a/secrets-management/cloud-kms/aws-kms/terraform/.gitignore
+++ b/secrets-management/cloud-kms/aws-kms/terraform/.gitignore
@@ -1,5 +1,4 @@
 .terraform/
-.terraform.lock.hcl
 *.tfstate
 *.tfstate.*
 terraform.tfvars

--- a/secrets-management/cloud-kms/aws-kms/terraform/.gitignore
+++ b/secrets-management/cloud-kms/aws-kms/terraform/.gitignore
@@ -3,3 +3,5 @@
 *.tfstate
 *.tfstate.*
 terraform.tfvars
+tfplan
+*.tfplan

--- a/secrets-management/cloud-kms/aws-kms/terraform/.terraform.lock.hcl
+++ b/secrets-management/cloud-kms/aws-kms/terraform/.terraform.lock.hcl
@@ -1,0 +1,67 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/coreweave/coreweave" {
+  version     = "0.13.0"
+  constraints = ">= 0.3.0"
+  hashes = [
+    "h1:uIKasrpZQYM9I9tLTGMZ7Lrcks5BLxppNBYKU+f1sSw=",
+    "zh:0812cb761bd60880cce3b8eeb673ef11132cdb9da5ed1fdb9a99f872bae8ead5",
+    "zh:0949f52968b97c46f8951f71f843eb0c7236dd7220ec7de06df2f1096b00433d",
+    "zh:0d484124e5a69390341a07c65113d12865643381ca551c0d0a7d74769e9541ae",
+    "zh:2785498bf810f143cf40a0349e822791db8fd1861766b793c1d301716883b4e4",
+    "zh:38b1e63fb299a3c295bdc59bd27e7a16944f3f3fa41a6440bbcfe97ddb803ce3",
+    "zh:541d4532c875b2ee7ecb98da9a1461e76788893b623b0adf7c634d9fff7770e3",
+    "zh:690ef29ba516f3b7c9b591a4d4dc53ee907778276e96d96ac7891e51537114fb",
+    "zh:6beb6a12971c7c30bda88c3ba2da58e3193d8d8ff9631b3615606a633acdd878",
+    "zh:7591708849998cfb87ca03d3c8cb2f07752246a4d287cc6f97f11bf885bc24d7",
+    "zh:bba3817b20fa933ce81e5226e98e087d081bed16cef22a2abadbd9b36e810cf2",
+    "zh:bda74818294d9734bea967f8de34eba515a93da5a2e3486172a458d0008023df",
+    "zh:db5ced7dded304418f955488f24d09cbf73ef93d442cbfe672cc5bc090996850",
+    "zh:dbb45b6d5cf9feb900403cdf6c61a6b85fb21d96d15815755529ff791bdeda07",
+    "zh:e6233b6db5d1e43aadab59159e39ff3d82ac0ec1985d6f265fd3a300bf3604c8",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.2.1"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:akFNuHwvrtnYMBofieoeXhPJDhYZzJVu/Q/BgZK2fgg=",
+    "zh:0d1e7d07ac973b97fa228f46596c800de830820506ee145626f079dd6bbf8d8a",
+    "zh:5c7e3d4348cb4861ab812973ef493814a4b224bdd3e9d534a7c8a7c992382b86",
+    "zh:7c6d4a86cd7a4e9c1025c6b3a3a6a45dea202af85d870cddbab455fb1bd568ad",
+    "zh:7d0864755ba093664c4b2c07c045d3f5e3d7c799dda1a3ef33d17ed1ac563191",
+    "zh:83734f57950ab67c0d6a87babdb3f13c908cbe0a48949333f489698532e1391b",
+    "zh:951e3c285218ebca0cf20eaa4265020b4ef042fea9c6ade115ad1558cfe459e5",
+    "zh:b9543955b4297e1d93b85900854891c0e645d936d8285a190030475379c5c635",
+    "zh:bb1bd9e86c003d08c30c1b00d44118ed5bbbf6b1d2d6f7eaac4fa5c6ebea5933",
+    "zh:c9477bfe00653629cd77ddac3968475f7ad93ac3ca8bc45b56d1d9efb25e4a6e",
+    "zh:d4cfda8687f736d0cba664c22ec49dae1188289e214ef57f5afe6a7217854fed",
+    "zh:dc77ee066cf96532a48f0578c35b1eaf6dc4d8ddd0e3ae8e029a3b10676dd5d3",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/secrets-management/cloud-kms/aws-kms/terraform/main.tf
+++ b/secrets-management/cloud-kms/aws-kms/terraform/main.tf
@@ -1,12 +1,61 @@
+data "terraform_remote_state" "cks" {
+  count = var.cks_remote_state_backend == null ? 0 : 1
+
+  backend = var.cks_remote_state_backend
+  config  = var.cks_remote_state_config
+}
+
 locals {
-  oidc_issuer_hostpath = trimsuffix(replace(var.oidc_issuer_url, "https://", ""), "/")
+  effective_oidc_issuer_url = coalesce(
+    var.oidc_issuer_url,
+    try(data.terraform_remote_state.cks[0].outputs.cks_service_account_oidc_issuer_url, null)
+  )
+
+  oidc_issuer_hostpath = trimsuffix(replace(local.effective_oidc_issuer_url, "https://", ""), "/")
   oidc_subject         = "system:serviceaccount:${var.namespace}:${var.service_account_name}"
+  effective_oidc_provider_arn = coalesce(
+    var.oidc_provider_arn,
+    try(aws_iam_openid_connect_provider.cks[0].arn, null)
+  )
 
   secret_names = {
     DB_USERNAME = "${var.secret_name_prefix}/db-username"
     DB_PASSWORD = "${var.secret_name_prefix}/db-password"
     API_TOKEN   = "${var.secret_name_prefix}/api-token"
   }
+}
+
+check "oidc_issuer_url_present" {
+  assert {
+    condition     = local.effective_oidc_issuer_url != null && trim(local.effective_oidc_issuer_url) != ""
+    error_message = "An OIDC issuer URL is required. Set oidc_issuer_url directly or configure cks_remote_state_* to read cks_service_account_oidc_issuer_url from your CKS terraform outputs."
+  }
+}
+
+check "oidc_provider_present" {
+  assert {
+    condition = (
+      var.create_oidc_provider ||
+      (local.effective_oidc_provider_arn != null && trim(local.effective_oidc_provider_arn) != "")
+    )
+    error_message = "An AWS IAM OIDC provider ARN is required when create_oidc_provider=false. Set oidc_provider_arn or enable create_oidc_provider."
+  }
+}
+
+data "tls_certificate" "oidc" {
+  count = var.create_oidc_provider ? 1 : 0
+  url   = local.effective_oidc_issuer_url
+}
+
+resource "aws_iam_openid_connect_provider" "cks" {
+  count = var.create_oidc_provider ? 1 : 0
+
+  url = local.effective_oidc_issuer_url
+
+  client_id_list = ["sts.amazonaws.com"]
+  thumbprint_list = [
+    data.tls_certificate.oidc[0].certificates[0].sha1_fingerprint,
+  ]
 }
 
 resource "aws_kms_key" "secrets" {
@@ -45,7 +94,7 @@ data "aws_iam_policy_document" "assume_role_with_web_identity" {
     principals {
       type = "Federated"
       identifiers = [
-        var.oidc_provider_arn,
+        local.effective_oidc_provider_arn,
       ]
     }
 

--- a/secrets-management/cloud-kms/aws-kms/terraform/main.tf
+++ b/secrets-management/cloud-kms/aws-kms/terraform/main.tf
@@ -1,0 +1,99 @@
+locals {
+  oidc_issuer_hostpath = trimsuffix(replace(var.oidc_issuer_url, "https://", ""), "/")
+  oidc_subject         = "system:serviceaccount:${var.namespace}:${var.service_account_name}"
+
+  secret_names = {
+    DB_USERNAME = "${var.secret_name_prefix}/db-username"
+    DB_PASSWORD = "${var.secret_name_prefix}/db-password"
+    API_TOKEN   = "${var.secret_name_prefix}/api-token"
+  }
+}
+
+resource "aws_kms_key" "secrets" {
+  description             = "KMS key for Secrets Manager entries used by the CoreWeave secrets reference architecture."
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
+
+resource "aws_kms_alias" "secrets" {
+  name          = var.kms_key_alias
+  target_key_id = aws_kms_key.secrets.key_id
+}
+
+resource "aws_secretsmanager_secret" "app" {
+  for_each = local.secret_names
+
+  name       = each.value
+  kms_key_id = aws_kms_key.secrets.arn
+}
+
+resource "aws_secretsmanager_secret_version" "app" {
+  for_each = local.secret_names
+
+  secret_id     = aws_secretsmanager_secret.app[each.key].id
+  secret_string = var.secret_values[each.key]
+}
+
+data "aws_iam_policy_document" "assume_role_with_web_identity" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "sts:AssumeRoleWithWebIdentity",
+    ]
+
+    principals {
+      type = "Federated"
+      identifiers = [
+        var.oidc_provider_arn,
+      ]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_issuer_hostpath}:sub"
+      values   = [local.oidc_subject]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_issuer_hostpath}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "eso_reader" {
+  name               = var.role_name
+  assume_role_policy = data.aws_iam_policy_document.assume_role_with_web_identity.json
+}
+
+data "aws_iam_policy_document" "read_secrets" {
+  statement {
+    sid    = "ReadReferencedSecrets"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:GetResourcePolicy",
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:ListSecretVersionIds",
+    ]
+    resources = [for secret in aws_secretsmanager_secret.app : secret.arn]
+  }
+
+  statement {
+    sid    = "DecryptSecretValues"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+    ]
+    resources = [aws_kms_key.secrets.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "read_secrets" {
+  name   = "${var.role_name}-policy"
+  role   = aws_iam_role.eso_reader.id
+  policy = data.aws_iam_policy_document.read_secrets.json
+}

--- a/secrets-management/cloud-kms/aws-kms/terraform/main.tf
+++ b/secrets-management/cloud-kms/aws-kms/terraform/main.tf
@@ -1,18 +1,10 @@
-data "terraform_remote_state" "cks" {
-  count = var.cks_remote_state_backend == null ? 0 : 1
-
-  backend = var.cks_remote_state_backend
-  config  = var.cks_remote_state_config
-}
-
 locals {
-  effective_oidc_issuer_url = coalesce(
-    var.oidc_issuer_url,
-    try(data.terraform_remote_state.cks[0].outputs.cks_service_account_oidc_issuer_url, null)
-  )
-
-  oidc_issuer_hostpath = trimsuffix(replace(local.effective_oidc_issuer_url, "https://", ""), "/")
-  oidc_subject         = "system:serviceaccount:${var.namespace}:${var.service_account_name}"
+  cks_pod_cidr_name          = var.vpc_prefixes[0].name
+  cks_service_cidr_name      = var.vpc_prefixes[1].name
+  cks_internal_lb_cidr_names = toset([for i in range(2, length(var.vpc_prefixes)) : var.vpc_prefixes[i].name])
+  effective_oidc_issuer_url  = module.cks.service_account_oidc_issuer_url
+  oidc_issuer_hostpath       = trimsuffix(replace(local.effective_oidc_issuer_url, "https://", ""), "/")
+  oidc_subject               = "system:serviceaccount:${var.namespace}:${var.service_account_name}"
   effective_oidc_provider_arn = coalesce(
     var.oidc_provider_arn,
     try(aws_iam_openid_connect_provider.cks[0].arn, null)
@@ -25,21 +17,36 @@ locals {
   }
 }
 
-check "oidc_issuer_url_present" {
-  assert {
-    condition     = local.effective_oidc_issuer_url != null && trim(local.effective_oidc_issuer_url) != ""
-    error_message = "An OIDC issuer URL is required. Set oidc_issuer_url directly or configure cks_remote_state_* to read cks_service_account_oidc_issuer_url from your CKS terraform outputs."
-  }
-}
-
 check "oidc_provider_present" {
   assert {
     condition = (
       var.create_oidc_provider ||
-      (local.effective_oidc_provider_arn != null && trim(local.effective_oidc_provider_arn) != "")
+      (local.effective_oidc_provider_arn != null && trimspace(local.effective_oidc_provider_arn) != "")
     )
     error_message = "An AWS IAM OIDC provider ARN is required when create_oidc_provider=false. Set oidc_provider_arn or enable create_oidc_provider."
   }
+}
+
+module "network" {
+  source = "../../../../terraform/modules/network"
+
+  name          = var.vpc_name
+  zone          = var.zone
+  vpc_prefixes  = var.vpc_prefixes
+  host_prefixes = var.host_prefixes
+}
+
+module "cks" {
+  source = "../../../../terraform/modules/cks"
+
+  cluster_name           = var.cluster_name
+  kubernetes_version     = var.kubernetes_version
+  zone                   = module.network.vpc_zone
+  vpc_id                 = module.network.vpc_id
+  public                 = var.cks_public
+  pod_cidr_name          = local.cks_pod_cidr_name
+  service_cidr_name      = local.cks_service_cidr_name
+  internal_lb_cidr_names = local.cks_internal_lb_cidr_names
 }
 
 data "tls_certificate" "oidc" {

--- a/secrets-management/cloud-kms/aws-kms/terraform/outputs.tf
+++ b/secrets-management/cloud-kms/aws-kms/terraform/outputs.tf
@@ -3,6 +3,16 @@ output "eso_role_arn" {
   value       = aws_iam_role.eso_reader.arn
 }
 
+output "effective_oidc_issuer_url" {
+  description = "Effective CKS OIDC issuer URL used by this stack."
+  value       = local.effective_oidc_issuer_url
+}
+
+output "effective_oidc_provider_arn" {
+  description = "Effective AWS IAM OIDC provider ARN used in IAM trust policy."
+  value       = local.effective_oidc_provider_arn
+}
+
 output "kms_key_arn" {
   description = "KMS key ARN used by Secrets Manager."
   value       = aws_kms_key.secrets.arn

--- a/secrets-management/cloud-kms/aws-kms/terraform/outputs.tf
+++ b/secrets-management/cloud-kms/aws-kms/terraform/outputs.tf
@@ -1,0 +1,24 @@
+output "eso_role_arn" {
+  description = "IAM role ARN to place in manifests/20-secret-store.yaml."
+  value       = aws_iam_role.eso_reader.arn
+}
+
+output "kms_key_arn" {
+  description = "KMS key ARN used by Secrets Manager."
+  value       = aws_kms_key.secrets.arn
+}
+
+output "secret_names" {
+  description = "Secrets Manager secret names referenced by manifests/30-external-secret.yaml."
+  value       = local.secret_names
+}
+
+output "namespace" {
+  description = "Kubernetes namespace expected by IAM trust policy."
+  value       = var.namespace
+}
+
+output "service_account_name" {
+  description = "Kubernetes service account expected by IAM trust policy."
+  value       = var.service_account_name
+}

--- a/secrets-management/cloud-kms/aws-kms/terraform/outputs.tf
+++ b/secrets-management/cloud-kms/aws-kms/terraform/outputs.tf
@@ -1,3 +1,33 @@
+output "vpc_id" {
+  description = "CoreWeave VPC ID created for this example."
+  value       = module.network.vpc_id
+}
+
+output "cks_cluster_id" {
+  description = "CKS cluster ID created for this example."
+  value       = module.cks.cluster_id
+}
+
+output "cks_cluster_name" {
+  description = "CKS cluster name created for this example."
+  value       = module.cks.cluster_name
+}
+
+output "cks_api_server_endpoint" {
+  description = "CKS Kubernetes API server endpoint."
+  value       = module.cks.api_server_endpoint
+}
+
+output "cks_status" {
+  description = "Current CKS cluster status."
+  value       = module.cks.status
+}
+
+output "cks_service_account_oidc_issuer_url" {
+  description = "CKS service-account OIDC issuer URL trusted by AWS IAM."
+  value       = module.cks.service_account_oidc_issuer_url
+}
+
 output "eso_role_arn" {
   description = "IAM role ARN to place in manifests/20-secret-store.yaml."
   value       = aws_iam_role.eso_reader.arn

--- a/secrets-management/cloud-kms/aws-kms/terraform/providers.tf
+++ b/secrets-management/cloud-kms/aws-kms/terraform/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.aws_region
+}

--- a/secrets-management/cloud-kms/aws-kms/terraform/providers.tf
+++ b/secrets-management/cloud-kms/aws-kms/terraform/providers.tf
@@ -1,3 +1,7 @@
+provider "coreweave" {
+  token = var.coreweave_api_token
+}
+
 provider "aws" {
   region = var.aws_region
 }

--- a/secrets-management/cloud-kms/aws-kms/terraform/terraform.tfvars.example
+++ b/secrets-management/cloud-kms/aws-kms/terraform/terraform.tfvars.example
@@ -1,6 +1,20 @@
 aws_region        = "us-east-1"
-oidc_issuer_url   = "https://oidc.cks.coreweave.com/id/replace-me"
-oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/oidc.cks.coreweave.com/id/replace-me"
+
+# Recommended: read OIDC issuer URL from this repo's CKS terraform outputs.
+# This expects you've already applied ../../../../terraform and have local state.
+cks_remote_state_backend = "local"
+cks_remote_state_config = {
+  path = "../../../../terraform/terraform.tfstate"
+}
+
+# Optional override if not using terraform_remote_state:
+# oidc_issuer_url = "https://oidc.cks.coreweave.com/id/replace-me"
+
+# Recommended: let this stack create the AWS OIDC provider automatically.
+create_oidc_provider = true
+
+# Only set this when create_oidc_provider = false:
+# oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/oidc.cks.coreweave.com/id/replace-me"
 
 namespace            = "secrets-aws"
 service_account_name = "eso-aws-auth"

--- a/secrets-management/cloud-kms/aws-kms/terraform/terraform.tfvars.example
+++ b/secrets-management/cloud-kms/aws-kms/terraform/terraform.tfvars.example
@@ -1,0 +1,15 @@
+aws_region        = "us-east-1"
+oidc_issuer_url   = "https://oidc.cks.coreweave.com/id/replace-me"
+oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/oidc.cks.coreweave.com/id/replace-me"
+
+namespace            = "secrets-aws"
+service_account_name = "eso-aws-auth"
+role_name            = "ra-eso-aws-secrets-reader"
+
+secret_name_prefix = "ra-demo"
+
+secret_values = {
+  DB_USERNAME = "demo-user"
+  DB_PASSWORD = "replace-me"
+  API_TOKEN   = "replace-me"
+}

--- a/secrets-management/cloud-kms/aws-kms/terraform/terraform.tfvars.example
+++ b/secrets-management/cloud-kms/aws-kms/terraform/terraform.tfvars.example
@@ -1,14 +1,24 @@
+# Set the CoreWeave token with:
+# export TF_VAR_coreweave_api_token="<YOUR_COREWEAVE_API_TOKEN>"
+
+# CoreWeave VPC + CKS cluster created by this example.
+zone               = "US-EAST-04A"
+vpc_name           = "ra-secrets-aws-vpc"
+cluster_name       = "ra-secrets-aws-cks"
+kubernetes_version = "v1.35"
+cks_public         = true
+
+vpc_prefixes = [
+  { name = "pod cidr", value = "10.0.0.0/13" },
+  { name = "service cidr", value = "10.16.0.0/22" },
+  { name = "internal lb cidr", value = "10.32.4.0/22" },
+]
+
+host_prefixes = [
+  { name = "primary", type = "PRIMARY", prefixes = ["10.16.192.0/18"] }
+]
+
 aws_region        = "us-east-1"
-
-# Recommended: read OIDC issuer URL from this repo's CKS terraform outputs.
-# This expects you've already applied ../../../../terraform and have local state.
-cks_remote_state_backend = "local"
-cks_remote_state_config = {
-  path = "../../../../terraform/terraform.tfstate"
-}
-
-# Optional override if not using terraform_remote_state:
-# oidc_issuer_url = "https://oidc.cks.coreweave.com/id/replace-me"
 
 # Recommended: let this stack create the AWS OIDC provider automatically.
 create_oidc_provider = true

--- a/secrets-management/cloud-kms/aws-kms/terraform/variables.tf
+++ b/secrets-management/cloud-kms/aws-kms/terraform/variables.tf
@@ -5,13 +5,33 @@ variable "aws_region" {
 }
 
 variable "oidc_issuer_url" {
-  description = "CKS OIDC issuer URL (for example: https://oidc.cks.coreweave.com/id/xxxxx)."
+  description = "Optional explicit CKS OIDC issuer URL. If unset, this can be sourced from cks_remote_state outputs."
   type        = string
+  default     = null
 }
 
 variable "oidc_provider_arn" {
-  description = "ARN of the AWS IAM OIDC provider registered for the CKS issuer."
+  description = "Optional existing AWS IAM OIDC provider ARN. Required only when create_oidc_provider is false."
   type        = string
+  default     = null
+}
+
+variable "create_oidc_provider" {
+  description = "When true, create an AWS IAM OIDC provider from the effective CKS OIDC issuer URL."
+  type        = bool
+  default     = true
+}
+
+variable "cks_remote_state_backend" {
+  description = "Optional terraform_remote_state backend for reading CKS outputs (for example: local, s3, gcs, remote)."
+  type        = string
+  default     = null
+}
+
+variable "cks_remote_state_config" {
+  description = "Optional terraform_remote_state backend config map used when cks_remote_state_backend is set."
+  type        = map(string)
+  default     = {}
 }
 
 variable "namespace" {

--- a/secrets-management/cloud-kms/aws-kms/terraform/variables.tf
+++ b/secrets-management/cloud-kms/aws-kms/terraform/variables.tf
@@ -1,0 +1,60 @@
+variable "aws_region" {
+  description = "AWS region for KMS and Secrets Manager."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "oidc_issuer_url" {
+  description = "CKS OIDC issuer URL (for example: https://oidc.cks.coreweave.com/id/xxxxx)."
+  type        = string
+}
+
+variable "oidc_provider_arn" {
+  description = "ARN of the AWS IAM OIDC provider registered for the CKS issuer."
+  type        = string
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace used by the AWS SecretStore and auth service account."
+  type        = string
+  default     = "secrets-aws"
+}
+
+variable "service_account_name" {
+  description = "Kubernetes service account used by ESO for AWS web identity."
+  type        = string
+  default     = "eso-aws-auth"
+}
+
+variable "role_name" {
+  description = "IAM role name that ESO assumes via web identity."
+  type        = string
+  default     = "ra-eso-aws-secrets-reader"
+}
+
+variable "kms_key_alias" {
+  description = "Alias for the KMS key used to encrypt Secrets Manager secrets."
+  type        = string
+  default     = "alias/ra-secrets-kms"
+}
+
+variable "secret_name_prefix" {
+  description = "Prefix used to name Secrets Manager secrets."
+  type        = string
+  default     = "ra-demo"
+}
+
+variable "secret_values" {
+  description = "Bootstrap secret values keyed by DB_USERNAME, DB_PASSWORD, and API_TOKEN."
+  type        = map(string)
+  sensitive   = true
+
+  validation {
+    condition = (
+      contains(keys(var.secret_values), "DB_USERNAME") &&
+      contains(keys(var.secret_values), "DB_PASSWORD") &&
+      contains(keys(var.secret_values), "API_TOKEN")
+    )
+    error_message = "secret_values must include DB_USERNAME, DB_PASSWORD, and API_TOKEN."
+  }
+}

--- a/secrets-management/cloud-kms/aws-kms/terraform/variables.tf
+++ b/secrets-management/cloud-kms/aws-kms/terraform/variables.tf
@@ -1,13 +1,72 @@
+variable "coreweave_api_token" {
+  description = "CoreWeave API token used to provision the VPC and CKS cluster. Prefer TF_VAR_coreweave_api_token."
+  type        = string
+  sensitive   = true
+}
+
+variable "zone" {
+  description = "CoreWeave zone for the VPC and CKS cluster."
+  type        = string
+}
+
+variable "vpc_name" {
+  description = "CoreWeave VPC name."
+  type        = string
+  default     = "ra-secrets-aws-vpc"
+}
+
+variable "vpc_prefixes" {
+  description = "Named VPC CIDR prefixes for CKS. Order: first=pod, second=service, remaining=internal LB."
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default = [
+    { name = "pod cidr", value = "10.0.0.0/13" },
+    { name = "service cidr", value = "10.16.0.0/22" },
+    { name = "internal lb cidr", value = "10.32.4.0/22" },
+  ]
+
+  validation {
+    condition     = length(var.vpc_prefixes) >= 3
+    error_message = "vpc_prefixes must include at least pod, service, and one internal load balancer CIDR."
+  }
+}
+
+variable "host_prefixes" {
+  description = "CoreWeave VPC host prefix definitions."
+  type = set(object({
+    name     = string
+    type     = string
+    prefixes = list(string)
+  }))
+  default = [
+    { name = "primary", type = "PRIMARY", prefixes = ["10.16.192.0/18"] }
+  ]
+}
+
+variable "cluster_name" {
+  description = "CKS cluster name."
+  type        = string
+  default     = "ra-secrets-aws-cks"
+}
+
+variable "kubernetes_version" {
+  description = "CKS Kubernetes minor version."
+  type        = string
+  default     = "v1.35"
+}
+
+variable "cks_public" {
+  description = "Whether the CKS API server is publicly reachable."
+  type        = bool
+  default     = true
+}
+
 variable "aws_region" {
   description = "AWS region for KMS and Secrets Manager."
   type        = string
   default     = "us-east-1"
-}
-
-variable "oidc_issuer_url" {
-  description = "Optional explicit CKS OIDC issuer URL. If unset, this can be sourced from cks_remote_state outputs."
-  type        = string
-  default     = null
 }
 
 variable "oidc_provider_arn" {
@@ -20,18 +79,6 @@ variable "create_oidc_provider" {
   description = "When true, create an AWS IAM OIDC provider from the effective CKS OIDC issuer URL."
   type        = bool
   default     = true
-}
-
-variable "cks_remote_state_backend" {
-  description = "Optional terraform_remote_state backend for reading CKS outputs (for example: local, s3, gcs, remote)."
-  type        = string
-  default     = null
-}
-
-variable "cks_remote_state_config" {
-  description = "Optional terraform_remote_state backend config map used when cks_remote_state_backend is set."
-  type        = map(string)
-  default     = {}
 }
 
 variable "namespace" {

--- a/secrets-management/cloud-kms/aws-kms/terraform/versions.tf
+++ b/secrets-management/cloud-kms/aws-kms/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/secrets-management/cloud-kms/aws-kms/terraform/versions.tf
+++ b/secrets-management/cloud-kms/aws-kms/terraform/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
   }
 }

--- a/secrets-management/cloud-kms/aws-kms/terraform/versions.tf
+++ b/secrets-management/cloud-kms/aws-kms/terraform/versions.tf
@@ -2,6 +2,10 @@ terraform {
   required_version = ">= 1.5.0"
 
   required_providers {
+    coreweave = {
+      source  = "coreweave/coreweave"
+      version = ">= 0.3.0"
+    }
     aws = {
       source  = "hashicorp/aws"
       version = "~> 5.0"

--- a/secrets-management/cloud-kms/gcp-kms/.gitignore
+++ b/secrets-management/cloud-kms/gcp-kms/.gitignore
@@ -1,0 +1,3 @@
+# Local-only files for following the tutorial:
+.envrc
+kubeconfig

--- a/secrets-management/cloud-kms/gcp-kms/README.md
+++ b/secrets-management/cloud-kms/gcp-kms/README.md
@@ -19,12 +19,13 @@ No static GCP service account key file is required.
   - Cloud KMS
   - Secret Manager
   - IAM bindings
-- CKS OIDC issuer URL from cluster details.
+- (Recommended) CKS provisioned with this repository's Terraform stack so `cks_service_account_oidc_issuer_url` is available as an output.
 - Terraform installed.
 
 ## Configure GCP Workload Identity Federation
 
-Create or reuse a Workload Identity Pool and OIDC provider that trust your CKS issuer.
+This Terraform stack can create Workload Identity Pool + OIDC provider automatically from the CKS issuer URL.
+It can also reuse an existing pool/provider if needed.
 
 Your IAM member for a specific Kubernetes service account should resolve to:
 
@@ -44,8 +45,17 @@ cp terraform.tfvars.example terraform.tfvars
 Set values in `terraform.tfvars`:
 - `project_id`
 - `project_number`
+- `cks_remote_state_*` (recommended) to auto-read `cks_service_account_oidc_issuer_url` from the CKS Terraform state.
 - `workload_identity_pool_id`
 - `secret_values`
+
+If you cannot use `terraform_remote_state`, set:
+- `cks_oidc_issuer_url` directly.
+
+By default, this stack creates Workload Identity Pool + Provider (`create_workload_identity_pool=true`).
+If your organization manages those centrally, set:
+- `create_workload_identity_pool = false`
+- `workload_identity_pool_id = <existing-pool-id>`
 
 Then apply:
 
@@ -64,6 +74,7 @@ terraform output
 You need:
 - `secret_names`
 - `workload_identity_principal`
+- `effective_cks_oidc_issuer_url`
 
 ## Configure and Apply Manifests
 

--- a/secrets-management/cloud-kms/gcp-kms/README.md
+++ b/secrets-management/cloud-kms/gcp-kms/README.md
@@ -1,0 +1,107 @@
+# GCP KMS + Secret Manager Reference
+
+This reference uses Google Secret Manager for secret storage, Cloud KMS (CMEK) for encryption at rest, and External Secrets Operator (ESO) for Kubernetes sync.
+
+## Architecture
+
+1. CKS OIDC issuer is configured as a trusted identity source in a GCP Workload Identity Pool.
+2. ESO uses Kubernetes service account identity to obtain short-lived GCP credentials.
+3. ESO reads secrets from Secret Manager (encrypted with a customer-managed Cloud KMS key).
+4. ESO syncs secrets into Kubernetes `app-runtime-secrets`.
+
+No static GCP service account key file is required.
+
+## Prerequisites
+
+- CKS cluster + ESO installed.
+- GCP project with permissions to manage:
+  - Workload Identity Federation
+  - Cloud KMS
+  - Secret Manager
+  - IAM bindings
+- CKS OIDC issuer URL from cluster details.
+- Terraform installed.
+
+## Configure GCP Workload Identity Federation
+
+Create or reuse a Workload Identity Pool and OIDC provider that trust your CKS issuer.
+
+Your IAM member for a specific Kubernetes service account should resolve to:
+
+`principal://iam.googleapis.com/projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/<POOL_ID>/subject/system:serviceaccount:<NAMESPACE>:<SERVICE_ACCOUNT_NAME>`
+
+This is the principal Terraform grants `roles/secretmanager.secretAccessor` permissions.
+
+## Provision GCP Resources
+
+From this directory:
+
+```bash
+cd terraform
+cp terraform.tfvars.example terraform.tfvars
+```
+
+Set values in `terraform.tfvars`:
+- `project_id`
+- `project_number`
+- `workload_identity_pool_id`
+- `secret_values`
+
+Then apply:
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+Capture outputs:
+
+```bash
+terraform output
+```
+
+You need:
+- `secret_names`
+- `workload_identity_principal`
+
+## Configure and Apply Manifests
+
+1. Update:
+- `manifests/20-secret-store.yaml`: `projectID`
+- If Terraform defaults were changed, update secret names in `manifests/30-external-secret.yaml`.
+
+2. Apply:
+
+```bash
+kubectl apply -f manifests/00-namespace.yaml
+kubectl apply -f manifests/10-service-account.yaml
+kubectl apply -f manifests/20-secret-store.yaml
+kubectl apply -f manifests/30-external-secret.yaml
+kubectl apply -f manifests/40-demo-app.yaml
+```
+
+## Verify
+
+```bash
+kubectl get secretstore,externalsecret -n secrets-gcp
+kubectl get secret app-runtime-secrets -n secrets-gcp
+kubectl logs deployment/secrets-demo -n secrets-gcp
+```
+
+## Rotation Test
+
+Rotate a secret in Secret Manager:
+
+```bash
+printf "rotated-password-%s" "$(date +%s)" | \
+  gcloud secrets versions add ra-demo-db-password \
+    --project <PROJECT_ID> \
+    --data-file=-
+```
+
+Wait for ESO refresh (1m), then verify Kubernetes Secret updated:
+
+```bash
+kubectl get secret app-runtime-secrets -n secrets-gcp -o yaml
+```

--- a/secrets-management/cloud-kms/gcp-kms/README.md
+++ b/secrets-management/cloud-kms/gcp-kms/README.md
@@ -22,6 +22,8 @@ No static GCP service account key file is required.
 - (Recommended) CKS provisioned with this repository's Terraform stack so `cks_service_account_oidc_issuer_url` is available as an output.
 - Terraform installed.
 
+`cks_service_account_oidc_issuer_url` comes from the read-only `service_account_oidc_issuer_url` field on `coreweave_cks_cluster`.
+
 ## Configure GCP Workload Identity Federation
 
 This Terraform stack can create Workload Identity Pool + OIDC provider automatically from the CKS issuer URL.

--- a/secrets-management/cloud-kms/gcp-kms/README.md
+++ b/secrets-management/cloud-kms/gcp-kms/README.md
@@ -1,20 +1,21 @@
 # GCP KMS + Secret Manager Tutorial
 
-This tutorial provisions a disposable CoreWeave VPC and CKS cluster, creates Google Secret Manager secrets encrypted with Cloud KMS, and verifies that External Secrets Operator syncs them into Kubernetes.
+This tutorial provisions a disposable CoreWeave VPC and CKS cluster, creates Google Secret Manager secrets encrypted with Cloud KMS, and verifies that External Secrets Operator syncs them into Kubernetes via direct Workload Identity Federation (no GKE required).
 
 ## Prerequisites
 
 - CoreWeave account permissions to create a VPC and CKS cluster.
 - A CoreWeave API token exported as `TF_VAR_coreweave_api_token`.
-- GCP credentials available to Terraform, for example through Application Default Credentials or `GOOGLE_APPLICATION_CREDENTIALS`.
-- A GCP project with these APIs enabled:
-  - `iam.googleapis.com`
-  - `cloudkms.googleapis.com`
-  - `secretmanager.googleapis.com`
-- GCP permissions to create Workload Identity Federation resources, Cloud KMS key rings and keys, Secret Manager secrets, and IAM bindings.
+- GCP credentials available to Terraform via Application Default Credentials (`gcloud auth application-default login`).
+- A GCP project where you can grant the IAM roles below. Terraform enables the required APIs (`iam`, `iamcredentials`, `sts`, `cloudkms`, `secretmanager`) automatically.
+- GCP IAM roles on your account (or a service account you impersonate):
+  - `roles/iam.workloadIdentityPoolAdmin`
+  - `roles/cloudkms.admin`
+  - `roles/secretmanager.admin`
+  - `roles/resourcemanager.projectIamAdmin` (or `roles/iam.securityAdmin`)
+  - `roles/serviceusage.serviceUsageAdmin`
 - Terraform `>= 1.5`, `kubectl`, `helm`, and `gcloud`.
 - Access to CoreWeave Console to download kubeconfig for the new CKS cluster.
-- Schedulable CKS node capacity for ESO and the demo app. If the cluster does not get capacity automatically, create a NodePool after the cluster is ready.
 
 ## 1. Configure Terraform
 
@@ -27,15 +28,16 @@ Edit `terraform.tfvars`:
 
 - Set `zone`, `vpc_name`, and `cluster_name`.
 - Set `project_id` and `project_number`.
-- Set `workload_identity_pool_id`.
+- Set `workload_identity_pool_id`. Pick a value that has not been used recently in this project — GCP soft-deletes pools for 30 days and refuses to recreate the same ID within that window.
 - Replace `secret_values`.
-- Keep `create_workload_identity_pool = true` unless your GCP project already has a pool for this CKS issuer.
+- Keep `create_workload_identity_pool = true` unless your GCP project already has a pool wired to this CKS issuer URL.
 
 Set credentials:
 
 ```bash
 export TF_VAR_coreweave_api_token="<COREWEAVE_API_TOKEN>"
 gcloud auth application-default login
+gcloud auth application-default set-quota-project "<PROJECT_ID>"
 gcloud config set project "<PROJECT_ID>"
 ```
 
@@ -48,11 +50,14 @@ terraform apply
 terraform output
 ```
 
-Record these outputs:
+Record these outputs — you will paste them into manifests in step 5:
 
 - `cks_cluster_name`
 - `secret_names`
-- `workload_identity_principal`
+- `eso_audience` — the WIF provider resource path that ESO must use as both the STS exchange audience and the K8s ServiceAccount token audience.
+- `workload_identity_principal` — the IAM principal granted Secret Manager access.
+
+The terraform run takes about 5 minutes (most of it is CKS cluster creation). If CKS returns `Internal Error / unavailable` after the provider's 11 internal retries, the chosen zone is most likely temporarily unable to create new clusters; pick another zone and re-run.
 
 ## 3. Connect To CKS
 
@@ -63,7 +68,7 @@ export KUBECONFIG="/path/to/downloaded/kubeconfig"
 kubectl get nodes
 ```
 
-If there are no schedulable nodes, apply the example CPU NodePool before continuing:
+If there are no schedulable nodes, create a NodePool. The example uses `cd-gp-i64-erapids`; not every CPU type is available in every zone, so check [Instance availability matrix](https://docs.coreweave.com/platform/instances/availability-matrix) and edit `manifests/cpu-nodepool.yaml` if you need a different `instanceType`.
 
 ```bash
 kubectl apply -f ../manifests/cpu-nodepool.yaml
@@ -71,9 +76,11 @@ kubectl get nodepool cpu
 kubectl wait --for=condition=Ready nodes --all --timeout=10m
 ```
 
-Edit `manifests/cpu-nodepool.yaml` if you need a different `instanceType` or `targetNodes`.
+If `kubectl get nodepool cpu` shows `VALIDATED=Invalid`, run `kubectl describe nodepool cpu` — the event log explains why (commonly `instance type does not exist in zone`).
 
 ## 4. Install ESO
+
+The `workloadIdentityFederation` auth path used here requires ESO with the GCP WIF support shipped in late 2025.
 
 ```bash
 helm repo add external-secrets https://charts.external-secrets.io
@@ -89,6 +96,7 @@ kubectl rollout status deployment/external-secrets -n external-secrets
 Edit `../manifests/20-secret-store.yaml`:
 
 - Set `spec.provider.gcpsm.projectID` to `project_id`.
+- Set both `spec.provider.gcpsm.auth.workloadIdentityFederation.audience` and `spec.provider.gcpsm.auth.workloadIdentityFederation.serviceAccountRef.audiences[0]` to the `eso_audience` value from `terraform output`. They must be identical — the first drives the STS token exchange, the second drives the K8s TokenRequest `aud` claim. If they don't match, GCP rejects the federation with `The audience in ID Token does not match the expected audience.`
 
 If you changed `secret_name_prefix`, update remote keys in `../manifests/30-external-secret.yaml` to match `secret_names`.
 
@@ -112,13 +120,15 @@ kubectl rollout status deployment/secrets-demo -n secrets-gcp
 kubectl logs deployment/secrets-demo -n secrets-gcp
 ```
 
-The demo logs should show:
+The SecretStore should report `Ready=True, Capabilities=ReadWrite`. The ExternalSecret should report `SecretSynced=True`. The demo logs should show:
 
 ```text
 DB_USERNAME loaded
 DB_PASSWORD loaded
 API_TOKEN loaded
 ```
+
+If the SecretStore reports `InvalidProviderConfig` with `audience ... does not match`, the two audience fields in step 5 are not identical or do not match the `eso_audience` output.
 
 ## 8. Test Rotation
 
@@ -129,7 +139,7 @@ printf "rotated-password-%s" "$(date +%s)" | \
     --data-file=-
 ```
 
-Wait at least one ESO refresh interval, then verify the Kubernetes Secret changed:
+Wait at least one ESO refresh interval (default 60s), then verify the Kubernetes Secret changed:
 
 ```bash
 kubectl get secret app-runtime-secrets -n secrets-gcp -o yaml
@@ -145,3 +155,10 @@ kubectl delete -f ../manifests/10-service-account.yaml --ignore-not-found
 kubectl delete -f ../manifests/00-namespace.yaml --ignore-not-found
 terraform destroy
 ```
+
+What `terraform destroy` does not fully clean up:
+
+- **Cloud KMS key rings cannot be deleted in GCP.** The key ring resource is removed from terraform state, but the ring lingers in your project forever. Pick a unique `kms_key_ring_name` per run, or accept the leftover.
+- Crypto key versions destroyed by terraform enter a 24-hour scheduled-destruction window before they are permanently gone.
+- The Workload Identity Pool soft-deletes for 30 days. Recreating the same `workload_identity_pool_id` within that window fails — either pick a new ID or undelete the pool.
+- The IAM bindings on each Secret Manager secret are torn down with the secret; nothing strands.

--- a/secrets-management/cloud-kms/gcp-kms/README.md
+++ b/secrets-management/cloud-kms/gcp-kms/README.md
@@ -1,120 +1,147 @@
-# GCP KMS + Secret Manager Reference
+# GCP KMS + Secret Manager Tutorial
 
-This reference uses Google Secret Manager for secret storage, Cloud KMS (CMEK) for encryption at rest, and External Secrets Operator (ESO) for Kubernetes sync.
-
-## Architecture
-
-1. CKS OIDC issuer is configured as a trusted identity source in a GCP Workload Identity Pool.
-2. ESO uses Kubernetes service account identity to obtain short-lived GCP credentials.
-3. ESO reads secrets from Secret Manager (encrypted with a customer-managed Cloud KMS key).
-4. ESO syncs secrets into Kubernetes `app-runtime-secrets`.
-
-No static GCP service account key file is required.
+This tutorial provisions a disposable CoreWeave VPC and CKS cluster, creates Google Secret Manager secrets encrypted with Cloud KMS, and verifies that External Secrets Operator syncs them into Kubernetes.
 
 ## Prerequisites
 
-- CKS cluster + ESO installed.
-- GCP project with permissions to manage:
-  - Workload Identity Federation
-  - Cloud KMS
-  - Secret Manager
-  - IAM bindings
-- (Recommended) CKS provisioned with this repository's Terraform stack so `cks_service_account_oidc_issuer_url` is available as an output.
-- Terraform installed.
+- CoreWeave account permissions to create a VPC and CKS cluster.
+- A CoreWeave API token exported as `TF_VAR_coreweave_api_token`.
+- GCP credentials available to Terraform, for example through Application Default Credentials or `GOOGLE_APPLICATION_CREDENTIALS`.
+- A GCP project with these APIs enabled:
+  - `iam.googleapis.com`
+  - `cloudkms.googleapis.com`
+  - `secretmanager.googleapis.com`
+- GCP permissions to create Workload Identity Federation resources, Cloud KMS key rings and keys, Secret Manager secrets, and IAM bindings.
+- Terraform `>= 1.5`, `kubectl`, `helm`, and `gcloud`.
+- Access to CoreWeave Console to download kubeconfig for the new CKS cluster.
+- Schedulable CKS node capacity for ESO and the demo app. If the cluster does not get capacity automatically, create a NodePool after the cluster is ready.
 
-`cks_service_account_oidc_issuer_url` comes from the read-only `service_account_oidc_issuer_url` field on `coreweave_cks_cluster`.
-
-## Configure GCP Workload Identity Federation
-
-This Terraform stack can create Workload Identity Pool + OIDC provider automatically from the CKS issuer URL.
-It can also reuse an existing pool/provider if needed.
-
-Your IAM member for a specific Kubernetes service account should resolve to:
-
-`principal://iam.googleapis.com/projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/<POOL_ID>/subject/system:serviceaccount:<NAMESPACE>:<SERVICE_ACCOUNT_NAME>`
-
-This is the principal Terraform grants `roles/secretmanager.secretAccessor` permissions.
-
-## Provision GCP Resources
-
-From this directory:
+## 1. Configure Terraform
 
 ```bash
 cd terraform
 cp terraform.tfvars.example terraform.tfvars
 ```
 
-Set values in `terraform.tfvars`:
-- `project_id`
-- `project_number`
-- `cks_remote_state_*` (recommended) to auto-read `cks_service_account_oidc_issuer_url` from the CKS Terraform state.
-- `workload_identity_pool_id`
-- `secret_values`
+Edit `terraform.tfvars`:
 
-If you cannot use `terraform_remote_state`, set:
-- `cks_oidc_issuer_url` directly.
+- Set `zone`, `vpc_name`, and `cluster_name`.
+- Set `project_id` and `project_number`.
+- Set `workload_identity_pool_id`.
+- Replace `secret_values`.
+- Keep `create_workload_identity_pool = true` unless your GCP project already has a pool for this CKS issuer.
 
-By default, this stack creates Workload Identity Pool + Provider (`create_workload_identity_pool=true`).
-If your organization manages those centrally, set:
-- `create_workload_identity_pool = false`
-- `workload_identity_pool_id = <existing-pool-id>`
+Set credentials:
 
-Then apply:
+```bash
+export TF_VAR_coreweave_api_token="<COREWEAVE_API_TOKEN>"
+gcloud auth application-default login
+gcloud config set project "<PROJECT_ID>"
+```
+
+## 2. Provision
 
 ```bash
 terraform init
 terraform plan
 terraform apply
-```
-
-Capture outputs:
-
-```bash
 terraform output
 ```
 
-You need:
+Record these outputs:
+
+- `cks_cluster_name`
 - `secret_names`
 - `workload_identity_principal`
-- `effective_cks_oidc_issuer_url`
 
-## Configure and Apply Manifests
+## 3. Connect To CKS
 
-1. Update:
-- `manifests/20-secret-store.yaml`: `projectID`
-- If Terraform defaults were changed, update secret names in `manifests/30-external-secret.yaml`.
-
-2. Apply:
+Download kubeconfig for `cks_cluster_name` from CoreWeave Console, then point `kubectl` at it:
 
 ```bash
-kubectl apply -f manifests/00-namespace.yaml
-kubectl apply -f manifests/10-service-account.yaml
-kubectl apply -f manifests/20-secret-store.yaml
-kubectl apply -f manifests/30-external-secret.yaml
-kubectl apply -f manifests/40-demo-app.yaml
+export KUBECONFIG="/path/to/downloaded/kubeconfig"
+kubectl get nodes
 ```
 
-## Verify
+If there are no schedulable nodes, apply the example CPU NodePool before continuing:
+
+```bash
+kubectl apply -f ../manifests/cpu-nodepool.yaml
+kubectl get nodepool cpu
+kubectl wait --for=condition=Ready nodes --all --timeout=10m
+```
+
+Edit `manifests/cpu-nodepool.yaml` if you need a different `instanceType` or `targetNodes`.
+
+## 4. Install ESO
+
+```bash
+helm repo add external-secrets https://charts.external-secrets.io
+helm repo update
+helm install external-secrets external-secrets/external-secrets \
+  --namespace external-secrets \
+  --create-namespace
+kubectl rollout status deployment/external-secrets -n external-secrets
+```
+
+## 5. Update Manifests
+
+Edit `../manifests/20-secret-store.yaml`:
+
+- Set `spec.provider.gcpsm.projectID` to `project_id`.
+
+If you changed `secret_name_prefix`, update remote keys in `../manifests/30-external-secret.yaml` to match `secret_names`.
+
+## 6. Apply Manifests
+
+```bash
+kubectl apply -f ../manifests/00-namespace.yaml
+kubectl apply -f ../manifests/10-service-account.yaml
+kubectl apply -f ../manifests/20-secret-store.yaml
+kubectl apply -f ../manifests/30-external-secret.yaml
+kubectl apply -f ../manifests/40-demo-app.yaml
+```
+
+## 7. Verify
 
 ```bash
 kubectl get secretstore,externalsecret -n secrets-gcp
+kubectl describe externalsecret app-secrets -n secrets-gcp
 kubectl get secret app-runtime-secrets -n secrets-gcp
+kubectl rollout status deployment/secrets-demo -n secrets-gcp
 kubectl logs deployment/secrets-demo -n secrets-gcp
 ```
 
-## Rotation Test
+The demo logs should show:
 
-Rotate a secret in Secret Manager:
+```text
+DB_USERNAME loaded
+DB_PASSWORD loaded
+API_TOKEN loaded
+```
+
+## 8. Test Rotation
 
 ```bash
 printf "rotated-password-%s" "$(date +%s)" | \
   gcloud secrets versions add ra-demo-db-password \
-    --project <PROJECT_ID> \
+    --project "<PROJECT_ID>" \
     --data-file=-
 ```
 
-Wait for ESO refresh (1m), then verify Kubernetes Secret updated:
+Wait at least one ESO refresh interval, then verify the Kubernetes Secret changed:
 
 ```bash
 kubectl get secret app-runtime-secrets -n secrets-gcp -o yaml
+```
+
+## 9. Clean Up
+
+```bash
+kubectl delete -f ../manifests/40-demo-app.yaml --ignore-not-found
+kubectl delete -f ../manifests/30-external-secret.yaml --ignore-not-found
+kubectl delete -f ../manifests/20-secret-store.yaml --ignore-not-found
+kubectl delete -f ../manifests/10-service-account.yaml --ignore-not-found
+kubectl delete -f ../manifests/00-namespace.yaml --ignore-not-found
+terraform destroy
 ```

--- a/secrets-management/cloud-kms/gcp-kms/env.example
+++ b/secrets-management/cloud-kms/gcp-kms/env.example
@@ -2,7 +2,15 @@ GCP_PROJECT_ID=replace-me
 GCP_PROJECT_NUMBER=123456789012
 GCP_REGION=us-central1
 GCP_SECRET_REPLICA_LOCATION=us-central1
-GCP_WIF_POOL_ID=replace-me
+
+# Recommended: derive issuer URL from CKS terraform output (cks_service_account_oidc_issuer_url).
+CKS_TFSTATE_PATH=../../../../terraform/terraform.tfstate
+
+# Optional manual override if remote state is not used:
+GCP_CKS_OIDC_ISSUER_URL=https://oidc.cks.coreweave.com/id/replace-me
+
+GCP_WIF_POOL_ID=cw-cks-secrets-pool
+GCP_WIF_PROVIDER_ID=cks-oidc
 GCP_WIF_SUBJECT=system:serviceaccount:secrets-gcp:eso-gcp-auth
 NAMESPACE=secrets-gcp
 SERVICE_ACCOUNT_NAME=eso-gcp-auth

--- a/secrets-management/cloud-kms/gcp-kms/env.example
+++ b/secrets-management/cloud-kms/gcp-kms/env.example
@@ -1,0 +1,8 @@
+GCP_PROJECT_ID=replace-me
+GCP_PROJECT_NUMBER=123456789012
+GCP_REGION=us-central1
+GCP_SECRET_REPLICA_LOCATION=us-central1
+GCP_WIF_POOL_ID=replace-me
+GCP_WIF_SUBJECT=system:serviceaccount:secrets-gcp:eso-gcp-auth
+NAMESPACE=secrets-gcp
+SERVICE_ACCOUNT_NAME=eso-gcp-auth

--- a/secrets-management/cloud-kms/gcp-kms/env.example
+++ b/secrets-management/cloud-kms/gcp-kms/env.example
@@ -1,16 +1,20 @@
+COREWEAVE_ZONE=US-EAST-04A
+COREWEAVE_VPC_NAME=ra-secrets-gcp-vpc
+CKS_CLUSTER_NAME=ra-secrets-gcp-cks
+CKS_KUBERNETES_VERSION=v1.35
 GCP_PROJECT_ID=replace-me
 GCP_PROJECT_NUMBER=123456789012
 GCP_REGION=us-central1
 GCP_SECRET_REPLICA_LOCATION=us-central1
 
-# Recommended: derive issuer URL from CKS terraform output (cks_service_account_oidc_issuer_url).
-CKS_TFSTATE_PATH=../../../../terraform/terraform.tfstate
-
-# Optional manual override if remote state is not used:
-GCP_CKS_OIDC_ISSUER_URL=https://oidc.cks.coreweave.com/id/replace-me
+# Terraform creates the CKS cluster and uses its service-account issuer URL directly.
+# Set TF_VAR_coreweave_api_token separately; do not store it in this file.
 
 GCP_WIF_POOL_ID=cw-cks-secrets-pool
 GCP_WIF_PROVIDER_ID=cks-oidc
 GCP_WIF_SUBJECT=system:serviceaccount:secrets-gcp:eso-gcp-auth
 NAMESPACE=secrets-gcp
 SERVICE_ACCOUNT_NAME=eso-gcp-auth
+
+# Path to the kubeconfig downloaded from CoreWeave Console for the CKS cluster.
+KUBECONFIG=/path/to/downloaded/kubeconfig

--- a/secrets-management/cloud-kms/gcp-kms/manifests/00-namespace.yaml
+++ b/secrets-management/cloud-kms/gcp-kms/manifests/00-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: secrets-gcp

--- a/secrets-management/cloud-kms/gcp-kms/manifests/10-service-account.yaml
+++ b/secrets-management/cloud-kms/gcp-kms/manifests/10-service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso-gcp-auth
+  namespace: secrets-gcp

--- a/secrets-management/cloud-kms/gcp-kms/manifests/20-secret-store.yaml
+++ b/secrets-management/cloud-kms/gcp-kms/manifests/20-secret-store.yaml
@@ -1,0 +1,13 @@
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: gcp-secretsmanager-store
+  namespace: secrets-gcp
+spec:
+  provider:
+    gcpsm:
+      projectID: "<REPLACE_GCP_PROJECT_ID>"
+      auth:
+        workloadIdentity:
+          serviceAccountRef:
+            name: eso-gcp-auth

--- a/secrets-management/cloud-kms/gcp-kms/manifests/20-secret-store.yaml
+++ b/secrets-management/cloud-kms/gcp-kms/manifests/20-secret-store.yaml
@@ -8,6 +8,14 @@ spec:
     gcpsm:
       projectID: "<REPLACE_GCP_PROJECT_ID>"
       auth:
-        workloadIdentity:
+        workloadIdentityFederation:
+          # ESO uses this audience as the STS exchange audience. Set both this
+          # value and serviceAccountRef.audiences to the same provider resource
+          # path, otherwise the K8s-issued token's aud claim will not match what
+          # the GCP WIF provider expects and credential exchange will fail with
+          # "The audience in ID Token does not match the expected audience."
+          audience: "<REPLACE_ESO_AUDIENCE>"
           serviceAccountRef:
             name: eso-gcp-auth
+            audiences:
+              - "<REPLACE_ESO_AUDIENCE>"

--- a/secrets-management/cloud-kms/gcp-kms/manifests/30-external-secret.yaml
+++ b/secrets-management/cloud-kms/gcp-kms/manifests/30-external-secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: app-secrets
+  namespace: secrets-gcp
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: gcp-secretsmanager-store
+    kind: SecretStore
+  target:
+    name: app-runtime-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: DB_USERNAME
+      remoteRef:
+        key: ra-demo-db-username
+    - secretKey: DB_PASSWORD
+      remoteRef:
+        key: ra-demo-db-password
+    - secretKey: API_TOKEN
+      remoteRef:
+        key: ra-demo-api-token

--- a/secrets-management/cloud-kms/gcp-kms/manifests/40-demo-app.yaml
+++ b/secrets-management/cloud-kms/gcp-kms/manifests/40-demo-app.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: secrets-demo
+  namespace: secrets-gcp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: secrets-demo
+  template:
+    metadata:
+      labels:
+        app: secrets-demo
+    spec:
+      containers:
+        - name: app
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              while true; do
+                date
+                [ -n "$DB_USERNAME" ] && echo "DB_USERNAME loaded"
+                [ -n "$DB_PASSWORD" ] && echo "DB_PASSWORD loaded"
+                [ -n "$API_TOKEN" ] && echo "API_TOKEN loaded"
+                sleep 30
+              done
+          envFrom:
+            - secretRef:
+                name: app-runtime-secrets

--- a/secrets-management/cloud-kms/gcp-kms/manifests/cpu-nodepool.yaml
+++ b/secrets-management/cloud-kms/gcp-kms/manifests/cpu-nodepool.yaml
@@ -1,0 +1,9 @@
+apiVersion: compute.coreweave.com/v1alpha1
+kind: NodePool
+metadata:
+  name: cpu
+spec:
+  instanceType: cd-gp-i64-erapids
+  targetNodes: 1
+  nodeConfigurationUpdateStrategy:
+    type: OnSpecUpdate

--- a/secrets-management/cloud-kms/gcp-kms/terraform/.gitignore
+++ b/secrets-management/cloud-kms/gcp-kms/terraform/.gitignore
@@ -1,0 +1,5 @@
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+terraform.tfvars

--- a/secrets-management/cloud-kms/gcp-kms/terraform/.gitignore
+++ b/secrets-management/cloud-kms/gcp-kms/terraform/.gitignore
@@ -1,5 +1,4 @@
 .terraform/
-.terraform.lock.hcl
 *.tfstate
 *.tfstate.*
 terraform.tfvars

--- a/secrets-management/cloud-kms/gcp-kms/terraform/.gitignore
+++ b/secrets-management/cloud-kms/gcp-kms/terraform/.gitignore
@@ -3,3 +3,5 @@
 *.tfstate
 *.tfstate.*
 terraform.tfvars
+tfplan
+*.tfplan

--- a/secrets-management/cloud-kms/gcp-kms/terraform/.terraform.lock.hcl
+++ b/secrets-management/cloud-kms/gcp-kms/terraform/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/coreweave/coreweave" {
+  version     = "0.13.0"
+  constraints = ">= 0.3.0"
+  hashes = [
+    "h1:uIKasrpZQYM9I9tLTGMZ7Lrcks5BLxppNBYKU+f1sSw=",
+    "zh:0812cb761bd60880cce3b8eeb673ef11132cdb9da5ed1fdb9a99f872bae8ead5",
+    "zh:0949f52968b97c46f8951f71f843eb0c7236dd7220ec7de06df2f1096b00433d",
+    "zh:0d484124e5a69390341a07c65113d12865643381ca551c0d0a7d74769e9541ae",
+    "zh:2785498bf810f143cf40a0349e822791db8fd1861766b793c1d301716883b4e4",
+    "zh:38b1e63fb299a3c295bdc59bd27e7a16944f3f3fa41a6440bbcfe97ddb803ce3",
+    "zh:541d4532c875b2ee7ecb98da9a1461e76788893b623b0adf7c634d9fff7770e3",
+    "zh:690ef29ba516f3b7c9b591a4d4dc53ee907778276e96d96ac7891e51537114fb",
+    "zh:6beb6a12971c7c30bda88c3ba2da58e3193d8d8ff9631b3615606a633acdd878",
+    "zh:7591708849998cfb87ca03d3c8cb2f07752246a4d287cc6f97f11bf885bc24d7",
+    "zh:bba3817b20fa933ce81e5226e98e087d081bed16cef22a2abadbd9b36e810cf2",
+    "zh:bda74818294d9734bea967f8de34eba515a93da5a2e3486172a458d0008023df",
+    "zh:db5ced7dded304418f955488f24d09cbf73ef93d442cbfe672cc5bc090996850",
+    "zh:dbb45b6d5cf9feb900403cdf6c61a6b85fb21d96d15815755529ff791bdeda07",
+    "zh:e6233b6db5d1e43aadab59159e39ff3d82ac0ec1985d6f265fd3a300bf3604c8",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:79CwMTsp3Ud1nOl5hFS5mxQHyT0fGVye7pqpU0PPlHI=",
+    "zh:1f3513fcfcbf7ca53d667a168c5067a4dd91a4d4cccd19743e248ff31065503c",
+    "zh:3da7db8fc2c51a77dd958ea8baaa05c29cd7f829bd8941c26e2ea9cb3aadc1e5",
+    "zh:3e09ac3f6ca8111cbb659d38c251771829f4347ab159a12db195e211c76068bb",
+    "zh:7bb9e41c568df15ccf1a8946037355eefb4dfb4e35e3b190808bb7c4abae547d",
+    "zh:81e5d78bdec7778e6d67b5c3544777505db40a826b6eb5abe9b86d4ba396866b",
+    "zh:8d309d020fb321525883f5c4ea864df3d5942b6087f6656d6d8b3a1377f340fc",
+    "zh:93e112559655ab95a523193158f4a4ac0f2bfed7eeaa712010b85ebb551d5071",
+    "zh:d3efe589ffd625b300cef5917c4629513f77e3a7b111c9df65075f76a46a63c7",
+    "zh:d4a4d672bbef756a870d8f32b35925f8ce2ef4f6bbd5b71a3cb764f1b6c85421",
+    "zh:e13a86bca299ba8a118e80d5f84fbdd708fe600ecdceea1a13d4919c068379fe",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fec30c095647b583a246c39d557704947195a1b7d41f81e369ba377d997faef6",
+  ]
+}

--- a/secrets-management/cloud-kms/gcp-kms/terraform/.terraform.lock.hcl
+++ b/secrets-management/cloud-kms/gcp-kms/terraform/.terraform.lock.hcl
@@ -42,3 +42,44 @@ provider "registry.terraform.io/hashicorp/google" {
     "zh:fec30c095647b583a246c39d557704947195a1b7d41f81e369ba377d997faef6",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:P2GiUJM1frlPtBViwKn1A9V2dVBdGuWcX80w9TdH8ZE=",
+    "zh:18b442bd0a05321d39dda1e9e3f1bdede4e61bc2ac62cc7a67037a3864f75101",
+    "zh:2e387c51455862828bec923a3ec81abf63a4d998da470cf00e09003bda53d668",
+    "zh:3942e708fa84ebe54996086f4b1398cb747fe19cbcd0be07ace528291fb35dee",
+    "zh:496287dd48b34ae6197cb1f887abeafd07c33f389dbe431bb01e24846754cfdd",
+    "zh:6eca885419969ce5c2a706f34dce1f10bde9774757675f2d8a92d12e5a1be390",
+    "zh:710dbef826c3fe7f76f844dae47937e8e4c1279dd9205ec4610be04cf3327244",
+    "zh:777ebf44b24bfc7bdbf770dc089f1a72f143b4718fdedb8c6bd75983115a1ec2",
+    "zh:9c8703bba37b8c7ad857efc3513392c5a096c519397c1cb822d7612f38e4262f",
+    "zh:c4f1d3a73de2702277c99d5348ad6d374705bcfdd367ad964ff4cfd2cf06c281",
+    "zh:eca8df11af3f5a948492d5b8b5d01b4ec705aad10bc30ec1524205508ae28393",
+    "zh:f41e7fd5f2628e8fd6b8ea136366923858f54428d1729898925469b862c275c2",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.14.0"
+  constraints = "~> 0.11"
+  hashes = [
+    "h1:/hlxsUpuN/lvPTNL9+NyVGsOyRsK5NsxwFMsj5CdOp4=",
+    "zh:12abfd6b800e4d7fa6db7310dec8ffd440b31993861ef188c7ed5260b3073937",
+    "zh:23005521e800bb19e1597bf755c5f70d675d30b685d4255001ed5fa47d9df3f1",
+    "zh:2fea249b582ae97cd1cc10385187ea50993bb47c28cc5df0305e57ceaabf0a10",
+    "zh:322018d3b987b7aad08697178029a2bb667bed699e88328f0c89c52a2fd41341",
+    "zh:32a08e98fce2d273cb9b2c89d6c54727cc9f0a32e15bfd896be4e02cc6b48f95",
+    "zh:3db89aabd0e619616bd4b0f8b373a7586dfe60feffcea12a84a0bdbc445714b3",
+    "zh:7488f56c81d742dc020f29063626c8f07ca188aa97be61e7307e8d62397020a2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7cb4067f2e7559b13f7562ef722f948950901eb37834873e98360ab28f66e9d7",
+    "zh:9d552c8345f61e1b7db8e725144981345f18ac1014d58d6f5ddf0928a195fffb",
+    "zh:a8e69fb6b97fc9d86fb19a9f4d42abe33c4a68e700b15387ce2e17d2b9934bed",
+    "zh:aeeb900eb8dd0f790c60ea5c0e0c8d42bd6e4a54f391681d4decca15b544394b",
+    "zh:c239c619101a8c95e1f14061eb973c57a8d15fa0e68878ced5bbd76858ee5b79",
+  ]
+}

--- a/secrets-management/cloud-kms/gcp-kms/terraform/main.tf
+++ b/secrets-management/cloud-kms/gcp-kms/terraform/main.tf
@@ -1,0 +1,61 @@
+locals {
+  effective_wif_subject = coalesce(var.wif_subject, "system:serviceaccount:${var.namespace}:${var.service_account_name}")
+
+  secret_names = {
+    DB_USERNAME = "${var.secret_name_prefix}-db-username"
+    DB_PASSWORD = "${var.secret_name_prefix}-db-password"
+    API_TOKEN   = "${var.secret_name_prefix}-api-token"
+  }
+}
+
+resource "google_kms_key_ring" "secrets" {
+  name     = var.kms_key_ring_name
+  location = var.kms_location
+  project  = var.project_id
+}
+
+resource "google_kms_crypto_key" "secrets" {
+  name            = var.kms_key_name
+  key_ring        = google_kms_key_ring.secrets.id
+  rotation_period = "7776000s"
+}
+
+resource "google_kms_crypto_key_iam_member" "secret_manager_service_agent" {
+  crypto_key_id = google_kms_crypto_key.secrets.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${var.project_number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+
+resource "google_secret_manager_secret" "app" {
+  for_each = local.secret_names
+
+  project   = var.project_id
+  secret_id = each.value
+
+  replication {
+    user_managed {
+      replicas {
+        location = var.secret_replica_location
+        customer_managed_encryption {
+          kms_key_name = google_kms_crypto_key.secrets.id
+        }
+      }
+    }
+  }
+}
+
+resource "google_secret_manager_secret_version" "app" {
+  for_each = local.secret_names
+
+  secret      = google_secret_manager_secret.app[each.key].id
+  secret_data = var.secret_values[each.key]
+}
+
+resource "google_secret_manager_secret_iam_member" "eso_reader" {
+  for_each = local.secret_names
+
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.app[each.key].secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "principal://iam.googleapis.com/projects/${var.project_number}/locations/global/workloadIdentityPools/${var.workload_identity_pool_id}/subject/${local.effective_wif_subject}"
+}

--- a/secrets-management/cloud-kms/gcp-kms/terraform/main.tf
+++ b/secrets-management/cloud-kms/gcp-kms/terraform/main.tf
@@ -1,10 +1,70 @@
+data "terraform_remote_state" "cks" {
+  count = var.cks_remote_state_backend == null ? 0 : 1
+
+  backend = var.cks_remote_state_backend
+  config  = var.cks_remote_state_config
+}
+
 locals {
+  effective_cks_oidc_issuer_url = coalesce(
+    var.cks_oidc_issuer_url,
+    try(data.terraform_remote_state.cks[0].outputs.cks_service_account_oidc_issuer_url, null)
+  )
+
   effective_wif_subject = coalesce(var.wif_subject, "system:serviceaccount:${var.namespace}:${var.service_account_name}")
+  effective_workload_identity_pool_id = coalesce(
+    var.workload_identity_pool_id,
+    try(google_iam_workload_identity_pool.cks[0].workload_identity_pool_id, null)
+  )
 
   secret_names = {
     DB_USERNAME = "${var.secret_name_prefix}-db-username"
     DB_PASSWORD = "${var.secret_name_prefix}-db-password"
     API_TOKEN   = "${var.secret_name_prefix}-api-token"
+  }
+}
+
+check "workload_identity_pool_id_present" {
+  assert {
+    condition     = var.workload_identity_pool_id != null && trim(var.workload_identity_pool_id) != ""
+    error_message = "workload_identity_pool_id must be set."
+  }
+}
+
+check "oidc_issuer_url_present_when_creating_pool" {
+  assert {
+    condition = (
+      !var.create_workload_identity_pool ||
+      (local.effective_cks_oidc_issuer_url != null && trim(local.effective_cks_oidc_issuer_url) != "")
+    )
+    error_message = "An OIDC issuer URL is required when create_workload_identity_pool=true. Set cks_oidc_issuer_url directly or configure cks_remote_state_* to read cks_service_account_oidc_issuer_url from your CKS terraform outputs."
+  }
+}
+
+resource "google_iam_workload_identity_pool" "cks" {
+  count = var.create_workload_identity_pool ? 1 : 0
+
+  project                   = var.project_id
+  workload_identity_pool_id = var.workload_identity_pool_id
+  display_name              = "CKS Secrets Workload Identity Pool"
+  description               = "OIDC federation pool for CKS service account identities used by ESO."
+}
+
+resource "google_iam_workload_identity_pool_provider" "cks_oidc" {
+  count = var.create_workload_identity_pool ? 1 : 0
+
+  project                            = var.project_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.cks[0].workload_identity_pool_id
+  workload_identity_pool_provider_id = var.workload_identity_provider_id
+  display_name                       = "CKS OIDC Provider"
+  description                        = "OIDC provider wired to the CKS service_account_oidc_issuer_url."
+
+  attribute_mapping = {
+    "google.subject" = "assertion.sub"
+  }
+
+  oidc {
+    issuer_uri = local.effective_cks_oidc_issuer_url
   }
 }
 
@@ -57,5 +117,5 @@ resource "google_secret_manager_secret_iam_member" "eso_reader" {
   project   = var.project_id
   secret_id = google_secret_manager_secret.app[each.key].secret_id
   role      = "roles/secretmanager.secretAccessor"
-  member    = "principal://iam.googleapis.com/projects/${var.project_number}/locations/global/workloadIdentityPools/${var.workload_identity_pool_id}/subject/${local.effective_wif_subject}"
+  member    = "principal://iam.googleapis.com/projects/${var.project_number}/locations/global/workloadIdentityPools/${local.effective_workload_identity_pool_id}/subject/${local.effective_wif_subject}"
 }

--- a/secrets-management/cloud-kms/gcp-kms/terraform/main.tf
+++ b/secrets-management/cloud-kms/gcp-kms/terraform/main.tf
@@ -1,17 +1,9 @@
-data "terraform_remote_state" "cks" {
-  count = var.cks_remote_state_backend == null ? 0 : 1
-
-  backend = var.cks_remote_state_backend
-  config  = var.cks_remote_state_config
-}
-
 locals {
-  effective_cks_oidc_issuer_url = coalesce(
-    var.cks_oidc_issuer_url,
-    try(data.terraform_remote_state.cks[0].outputs.cks_service_account_oidc_issuer_url, null)
-  )
-
-  effective_wif_subject = coalesce(var.wif_subject, "system:serviceaccount:${var.namespace}:${var.service_account_name}")
+  cks_pod_cidr_name             = var.vpc_prefixes[0].name
+  cks_service_cidr_name         = var.vpc_prefixes[1].name
+  cks_internal_lb_cidr_names    = toset([for i in range(2, length(var.vpc_prefixes)) : var.vpc_prefixes[i].name])
+  effective_cks_oidc_issuer_url = module.cks.service_account_oidc_issuer_url
+  effective_wif_subject         = coalesce(var.wif_subject, "system:serviceaccount:${var.namespace}:${var.service_account_name}")
   effective_workload_identity_pool_id = coalesce(
     var.workload_identity_pool_id,
     try(google_iam_workload_identity_pool.cks[0].workload_identity_pool_id, null)
@@ -26,19 +18,31 @@ locals {
 
 check "workload_identity_pool_id_present" {
   assert {
-    condition     = var.workload_identity_pool_id != null && trim(var.workload_identity_pool_id) != ""
+    condition     = var.workload_identity_pool_id != null && trimspace(var.workload_identity_pool_id) != ""
     error_message = "workload_identity_pool_id must be set."
   }
 }
 
-check "oidc_issuer_url_present_when_creating_pool" {
-  assert {
-    condition = (
-      !var.create_workload_identity_pool ||
-      (local.effective_cks_oidc_issuer_url != null && trim(local.effective_cks_oidc_issuer_url) != "")
-    )
-    error_message = "An OIDC issuer URL is required when create_workload_identity_pool=true. Set cks_oidc_issuer_url directly or configure cks_remote_state_* to read cks_service_account_oidc_issuer_url from your CKS terraform outputs."
-  }
+module "network" {
+  source = "../../../../terraform/modules/network"
+
+  name          = var.vpc_name
+  zone          = var.zone
+  vpc_prefixes  = var.vpc_prefixes
+  host_prefixes = var.host_prefixes
+}
+
+module "cks" {
+  source = "../../../../terraform/modules/cks"
+
+  cluster_name           = var.cluster_name
+  kubernetes_version     = var.kubernetes_version
+  zone                   = module.network.vpc_zone
+  vpc_id                 = module.network.vpc_id
+  public                 = var.cks_public
+  pod_cidr_name          = local.cks_pod_cidr_name
+  service_cidr_name      = local.cks_service_cidr_name
+  internal_lb_cidr_names = local.cks_internal_lb_cidr_names
 }
 
 resource "google_iam_workload_identity_pool" "cks" {

--- a/secrets-management/cloud-kms/gcp-kms/terraform/main.tf
+++ b/secrets-management/cloud-kms/gcp-kms/terraform/main.tf
@@ -9,11 +9,43 @@ locals {
     try(google_iam_workload_identity_pool.cks[0].workload_identity_pool_id, null)
   )
 
+  eso_audience = "//iam.googleapis.com/projects/${var.project_number}/locations/global/workloadIdentityPools/${local.effective_workload_identity_pool_id}/providers/${var.workload_identity_provider_id}"
+
   secret_names = {
     DB_USERNAME = "${var.secret_name_prefix}-db-username"
     DB_PASSWORD = "${var.secret_name_prefix}-db-password"
     API_TOKEN   = "${var.secret_name_prefix}-api-token"
   }
+
+  required_services = toset([
+    "iam.googleapis.com",
+    "iamcredentials.googleapis.com",
+    "sts.googleapis.com",
+    "cloudkms.googleapis.com",
+    "secretmanager.googleapis.com",
+  ])
+}
+
+resource "google_project_service" "required" {
+  for_each = local.required_services
+
+  project            = var.project_id
+  service            = each.value
+  disable_on_destroy = false
+}
+
+resource "google_project_service_identity" "secretmanager" {
+  provider = google-beta
+
+  project = var.project_id
+  service = "secretmanager.googleapis.com"
+
+  depends_on = [google_project_service.required]
+}
+
+resource "time_sleep" "wait_for_sm_service_identity" {
+  depends_on      = [google_project_service_identity.secretmanager]
+  create_duration = "60s"
 }
 
 check "workload_identity_pool_id_present" {
@@ -50,8 +82,10 @@ resource "google_iam_workload_identity_pool" "cks" {
 
   project                   = var.project_id
   workload_identity_pool_id = var.workload_identity_pool_id
-  display_name              = "CKS Secrets Workload Identity Pool"
+  display_name              = "CKS Secrets WIF Pool"
   description               = "OIDC federation pool for CKS service account identities used by ESO."
+
+  depends_on = [google_project_service.required]
 }
 
 resource "google_iam_workload_identity_pool_provider" "cks_oidc" {
@@ -67,8 +101,13 @@ resource "google_iam_workload_identity_pool_provider" "cks_oidc" {
     "google.subject" = "assertion.sub"
   }
 
+  attribute_condition = "assertion.sub.startsWith(\"system:serviceaccount:${var.namespace}:\")"
+
   oidc {
     issuer_uri = local.effective_cks_oidc_issuer_url
+    allowed_audiences = [
+      "//iam.googleapis.com/projects/${var.project_number}/locations/global/workloadIdentityPools/${var.workload_identity_pool_id}/providers/${var.workload_identity_provider_id}",
+    ]
   }
 }
 
@@ -76,6 +115,8 @@ resource "google_kms_key_ring" "secrets" {
   name     = var.kms_key_ring_name
   location = var.kms_location
   project  = var.project_id
+
+  depends_on = [google_project_service.required]
 }
 
 resource "google_kms_crypto_key" "secrets" {
@@ -87,7 +128,9 @@ resource "google_kms_crypto_key" "secrets" {
 resource "google_kms_crypto_key_iam_member" "secret_manager_service_agent" {
   crypto_key_id = google_kms_crypto_key.secrets.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:service-${var.project_number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+  member        = "serviceAccount:${google_project_service_identity.secretmanager.email}"
+
+  depends_on = [time_sleep.wait_for_sm_service_identity]
 }
 
 resource "google_secret_manager_secret" "app" {
@@ -106,6 +149,8 @@ resource "google_secret_manager_secret" "app" {
       }
     }
   }
+
+  depends_on = [google_kms_crypto_key_iam_member.secret_manager_service_agent]
 }
 
 resource "google_secret_manager_secret_version" "app" {

--- a/secrets-management/cloud-kms/gcp-kms/terraform/outputs.tf
+++ b/secrets-management/cloud-kms/gcp-kms/terraform/outputs.tf
@@ -3,6 +3,21 @@ output "kms_crypto_key_id" {
   value       = google_kms_crypto_key.secrets.id
 }
 
+output "effective_cks_oidc_issuer_url" {
+  description = "Effective CKS OIDC issuer URL used for Workload Identity Federation."
+  value       = local.effective_cks_oidc_issuer_url
+}
+
+output "workload_identity_pool_id" {
+  description = "Effective Workload Identity Pool ID used for Secret Manager access."
+  value       = local.effective_workload_identity_pool_id
+}
+
+output "workload_identity_provider_name" {
+  description = "Created Workload Identity Provider resource name (null when create_workload_identity_pool=false)."
+  value       = try(google_iam_workload_identity_pool_provider.cks_oidc[0].name, null)
+}
+
 output "secret_names" {
   description = "Secret Manager secret names referenced by manifests/30-external-secret.yaml."
   value       = local.secret_names
@@ -10,7 +25,7 @@ output "secret_names" {
 
 output "workload_identity_principal" {
   description = "Workload Identity principal granted Secret Manager access."
-  value       = "principal://iam.googleapis.com/projects/${var.project_number}/locations/global/workloadIdentityPools/${var.workload_identity_pool_id}/subject/${local.effective_wif_subject}"
+  value       = "principal://iam.googleapis.com/projects/${var.project_number}/locations/global/workloadIdentityPools/${local.effective_workload_identity_pool_id}/subject/${local.effective_wif_subject}"
 }
 
 output "namespace" {

--- a/secrets-management/cloud-kms/gcp-kms/terraform/outputs.tf
+++ b/secrets-management/cloud-kms/gcp-kms/terraform/outputs.tf
@@ -1,0 +1,24 @@
+output "kms_crypto_key_id" {
+  description = "Cloud KMS key identifier used for secret encryption."
+  value       = google_kms_crypto_key.secrets.id
+}
+
+output "secret_names" {
+  description = "Secret Manager secret names referenced by manifests/30-external-secret.yaml."
+  value       = local.secret_names
+}
+
+output "workload_identity_principal" {
+  description = "Workload Identity principal granted Secret Manager access."
+  value       = "principal://iam.googleapis.com/projects/${var.project_number}/locations/global/workloadIdentityPools/${var.workload_identity_pool_id}/subject/${local.effective_wif_subject}"
+}
+
+output "namespace" {
+  description = "Kubernetes namespace expected by the default workload identity subject."
+  value       = var.namespace
+}
+
+output "service_account_name" {
+  description = "Kubernetes service account expected by the default workload identity subject."
+  value       = var.service_account_name
+}

--- a/secrets-management/cloud-kms/gcp-kms/terraform/outputs.tf
+++ b/secrets-management/cloud-kms/gcp-kms/terraform/outputs.tf
@@ -1,3 +1,33 @@
+output "vpc_id" {
+  description = "CoreWeave VPC ID created for this example."
+  value       = module.network.vpc_id
+}
+
+output "cks_cluster_id" {
+  description = "CKS cluster ID created for this example."
+  value       = module.cks.cluster_id
+}
+
+output "cks_cluster_name" {
+  description = "CKS cluster name created for this example."
+  value       = module.cks.cluster_name
+}
+
+output "cks_api_server_endpoint" {
+  description = "CKS Kubernetes API server endpoint."
+  value       = module.cks.api_server_endpoint
+}
+
+output "cks_status" {
+  description = "Current CKS cluster status."
+  value       = module.cks.status
+}
+
+output "cks_service_account_oidc_issuer_url" {
+  description = "CKS service-account OIDC issuer URL trusted by GCP Workload Identity Federation."
+  value       = module.cks.service_account_oidc_issuer_url
+}
+
 output "kms_crypto_key_id" {
   description = "Cloud KMS key identifier used for secret encryption."
   value       = google_kms_crypto_key.secrets.id

--- a/secrets-management/cloud-kms/gcp-kms/terraform/outputs.tf
+++ b/secrets-management/cloud-kms/gcp-kms/terraform/outputs.tf
@@ -58,6 +58,11 @@ output "workload_identity_principal" {
   value       = "principal://iam.googleapis.com/projects/${var.project_number}/locations/global/workloadIdentityPools/${local.effective_workload_identity_pool_id}/subject/${local.effective_wif_subject}"
 }
 
+output "eso_audience" {
+  description = "WIF provider audience that the ESO SecretStore must request (paste into manifests/20-secret-store.yaml)."
+  value       = local.eso_audience
+}
+
 output "namespace" {
   description = "Kubernetes namespace expected by the default workload identity subject."
   value       = var.namespace

--- a/secrets-management/cloud-kms/gcp-kms/terraform/providers.tf
+++ b/secrets-management/cloud-kms/gcp-kms/terraform/providers.tf
@@ -1,0 +1,4 @@
+provider "google" {
+  project = var.project_id
+  region  = var.gcp_region
+}

--- a/secrets-management/cloud-kms/gcp-kms/terraform/providers.tf
+++ b/secrets-management/cloud-kms/gcp-kms/terraform/providers.tf
@@ -1,3 +1,7 @@
+provider "coreweave" {
+  token = var.coreweave_api_token
+}
+
 provider "google" {
   project = var.project_id
   region  = var.gcp_region

--- a/secrets-management/cloud-kms/gcp-kms/terraform/providers.tf
+++ b/secrets-management/cloud-kms/gcp-kms/terraform/providers.tf
@@ -6,3 +6,8 @@ provider "google" {
   project = var.project_id
   region  = var.gcp_region
 }
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.gcp_region
+}

--- a/secrets-management/cloud-kms/gcp-kms/terraform/terraform.tfvars.example
+++ b/secrets-management/cloud-kms/gcp-kms/terraform/terraform.tfvars.example
@@ -1,0 +1,20 @@
+project_id     = "replace-me"
+project_number = "123456789012"
+
+gcp_region              = "us-central1"
+kms_location            = "us-central1"
+secret_replica_location = "us-central1"
+
+workload_identity_pool_id = "replace-me"
+wif_subject               = "system:serviceaccount:secrets-gcp:eso-gcp-auth"
+
+namespace            = "secrets-gcp"
+service_account_name = "eso-gcp-auth"
+
+secret_name_prefix = "ra-demo"
+
+secret_values = {
+  DB_USERNAME = "demo-user"
+  DB_PASSWORD = "replace-me"
+  API_TOKEN   = "replace-me"
+}

--- a/secrets-management/cloud-kms/gcp-kms/terraform/terraform.tfvars.example
+++ b/secrets-management/cloud-kms/gcp-kms/terraform/terraform.tfvars.example
@@ -5,7 +5,19 @@ gcp_region              = "us-central1"
 kms_location            = "us-central1"
 secret_replica_location = "us-central1"
 
-workload_identity_pool_id = "replace-me"
+# Recommended: read OIDC issuer URL from this repo's CKS terraform outputs.
+# This expects you've already applied ../../../../terraform and have local state.
+cks_remote_state_backend = "local"
+cks_remote_state_config = {
+  path = "../../../../terraform/terraform.tfstate"
+}
+
+# Optional override if not using terraform_remote_state:
+# cks_oidc_issuer_url = "https://oidc.cks.coreweave.com/id/replace-me"
+
+create_workload_identity_pool = true
+workload_identity_pool_id     = "cw-cks-secrets-pool"
+workload_identity_provider_id = "cks-oidc"
 wif_subject               = "system:serviceaccount:secrets-gcp:eso-gcp-auth"
 
 namespace            = "secrets-gcp"

--- a/secrets-management/cloud-kms/gcp-kms/terraform/terraform.tfvars.example
+++ b/secrets-management/cloud-kms/gcp-kms/terraform/terraform.tfvars.example
@@ -1,3 +1,23 @@
+# Set the CoreWeave token with:
+# export TF_VAR_coreweave_api_token="<YOUR_COREWEAVE_API_TOKEN>"
+
+# CoreWeave VPC + CKS cluster created by this example.
+zone               = "US-EAST-04A"
+vpc_name           = "ra-secrets-gcp-vpc"
+cluster_name       = "ra-secrets-gcp-cks"
+kubernetes_version = "v1.35"
+cks_public         = true
+
+vpc_prefixes = [
+  { name = "pod cidr", value = "10.0.0.0/13" },
+  { name = "service cidr", value = "10.16.0.0/22" },
+  { name = "internal lb cidr", value = "10.32.4.0/22" },
+]
+
+host_prefixes = [
+  { name = "primary", type = "PRIMARY", prefixes = ["10.16.192.0/18"] }
+]
+
 project_id     = "replace-me"
 project_number = "123456789012"
 
@@ -5,20 +25,10 @@ gcp_region              = "us-central1"
 kms_location            = "us-central1"
 secret_replica_location = "us-central1"
 
-# Recommended: read OIDC issuer URL from this repo's CKS terraform outputs.
-# This expects you've already applied ../../../../terraform and have local state.
-cks_remote_state_backend = "local"
-cks_remote_state_config = {
-  path = "../../../../terraform/terraform.tfstate"
-}
-
-# Optional override if not using terraform_remote_state:
-# cks_oidc_issuer_url = "https://oidc.cks.coreweave.com/id/replace-me"
-
 create_workload_identity_pool = true
 workload_identity_pool_id     = "cw-cks-secrets-pool"
 workload_identity_provider_id = "cks-oidc"
-wif_subject               = "system:serviceaccount:secrets-gcp:eso-gcp-auth"
+wif_subject                   = "system:serviceaccount:secrets-gcp:eso-gcp-auth"
 
 namespace            = "secrets-gcp"
 service_account_name = "eso-gcp-auth"

--- a/secrets-management/cloud-kms/gcp-kms/terraform/variables.tf
+++ b/secrets-management/cloud-kms/gcp-kms/terraform/variables.tf
@@ -1,0 +1,83 @@
+variable "project_id" {
+  description = "GCP project ID."
+  type        = string
+}
+
+variable "project_number" {
+  description = "GCP project number used to build Workload Identity principal strings."
+  type        = string
+}
+
+variable "gcp_region" {
+  description = "Default region for provider operations."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "kms_location" {
+  description = "Cloud KMS location for the key ring and crypto key."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "secret_replica_location" {
+  description = "Secret Manager replica location used for user-managed replication."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "kms_key_ring_name" {
+  description = "KMS key ring name."
+  type        = string
+  default     = "ra-secrets-ring"
+}
+
+variable "kms_key_name" {
+  description = "KMS crypto key name."
+  type        = string
+  default     = "ra-secrets-key"
+}
+
+variable "secret_name_prefix" {
+  description = "Prefix used to name Secret Manager secrets."
+  type        = string
+  default     = "ra-demo"
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace used by the GCP SecretStore and auth service account."
+  type        = string
+  default     = "secrets-gcp"
+}
+
+variable "service_account_name" {
+  description = "Kubernetes service account used by ESO for GCP workload identity."
+  type        = string
+  default     = "eso-gcp-auth"
+}
+
+variable "workload_identity_pool_id" {
+  description = "Workload Identity Pool ID that trusts the CKS OIDC issuer."
+  type        = string
+}
+
+variable "wif_subject" {
+  description = "Optional custom workload identity subject. If null, defaults to system:serviceaccount:<namespace>:<service_account_name>."
+  type        = string
+  default     = null
+}
+
+variable "secret_values" {
+  description = "Bootstrap secret values keyed by DB_USERNAME, DB_PASSWORD, and API_TOKEN."
+  type        = map(string)
+  sensitive   = true
+
+  validation {
+    condition = (
+      contains(keys(var.secret_values), "DB_USERNAME") &&
+      contains(keys(var.secret_values), "DB_PASSWORD") &&
+      contains(keys(var.secret_values), "API_TOKEN")
+    )
+    error_message = "secret_values must include DB_USERNAME, DB_PASSWORD, and API_TOKEN."
+  }
+}

--- a/secrets-management/cloud-kms/gcp-kms/terraform/variables.tf
+++ b/secrets-management/cloud-kms/gcp-kms/terraform/variables.tf
@@ -57,8 +57,39 @@ variable "service_account_name" {
 }
 
 variable "workload_identity_pool_id" {
-  description = "Workload Identity Pool ID that trusts the CKS OIDC issuer."
+  description = "Workload Identity Pool ID. Required when create_workload_identity_pool=true, or when reusing an existing pool."
   type        = string
+  default     = null
+}
+
+variable "workload_identity_provider_id" {
+  description = "Workload Identity Pool Provider ID used when create_workload_identity_pool=true."
+  type        = string
+  default     = "cks-oidc"
+}
+
+variable "create_workload_identity_pool" {
+  description = "When true, create Workload Identity Pool + OIDC Provider using the effective CKS OIDC issuer URL."
+  type        = bool
+  default     = true
+}
+
+variable "cks_oidc_issuer_url" {
+  description = "Optional explicit CKS OIDC issuer URL. If unset, this can be sourced from cks_remote_state outputs."
+  type        = string
+  default     = null
+}
+
+variable "cks_remote_state_backend" {
+  description = "Optional terraform_remote_state backend for reading CKS outputs (for example: local, s3, gcs, remote)."
+  type        = string
+  default     = null
+}
+
+variable "cks_remote_state_config" {
+  description = "Optional terraform_remote_state backend config map used when cks_remote_state_backend is set."
+  type        = map(string)
+  default     = {}
 }
 
 variable "wif_subject" {

--- a/secrets-management/cloud-kms/gcp-kms/terraform/variables.tf
+++ b/secrets-management/cloud-kms/gcp-kms/terraform/variables.tf
@@ -122,9 +122,8 @@ variable "service_account_name" {
 }
 
 variable "workload_identity_pool_id" {
-  description = "Workload Identity Pool ID. Required when create_workload_identity_pool=true, or when reusing an existing pool."
+  description = "Workload Identity Pool ID. Required: used both when create_workload_identity_pool=true and when reusing an existing pool."
   type        = string
-  default     = null
 }
 
 variable "workload_identity_provider_id" {

--- a/secrets-management/cloud-kms/gcp-kms/terraform/variables.tf
+++ b/secrets-management/cloud-kms/gcp-kms/terraform/variables.tf
@@ -1,3 +1,68 @@
+variable "coreweave_api_token" {
+  description = "CoreWeave API token used to provision the VPC and CKS cluster. Prefer TF_VAR_coreweave_api_token."
+  type        = string
+  sensitive   = true
+}
+
+variable "zone" {
+  description = "CoreWeave zone for the VPC and CKS cluster."
+  type        = string
+}
+
+variable "vpc_name" {
+  description = "CoreWeave VPC name."
+  type        = string
+  default     = "ra-secrets-gcp-vpc"
+}
+
+variable "vpc_prefixes" {
+  description = "Named VPC CIDR prefixes for CKS. Order: first=pod, second=service, remaining=internal LB."
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default = [
+    { name = "pod cidr", value = "10.0.0.0/13" },
+    { name = "service cidr", value = "10.16.0.0/22" },
+    { name = "internal lb cidr", value = "10.32.4.0/22" },
+  ]
+
+  validation {
+    condition     = length(var.vpc_prefixes) >= 3
+    error_message = "vpc_prefixes must include at least pod, service, and one internal load balancer CIDR."
+  }
+}
+
+variable "host_prefixes" {
+  description = "CoreWeave VPC host prefix definitions."
+  type = set(object({
+    name     = string
+    type     = string
+    prefixes = list(string)
+  }))
+  default = [
+    { name = "primary", type = "PRIMARY", prefixes = ["10.16.192.0/18"] }
+  ]
+}
+
+variable "cluster_name" {
+  description = "CKS cluster name."
+  type        = string
+  default     = "ra-secrets-gcp-cks"
+}
+
+variable "kubernetes_version" {
+  description = "CKS Kubernetes minor version."
+  type        = string
+  default     = "v1.35"
+}
+
+variable "cks_public" {
+  description = "Whether the CKS API server is publicly reachable."
+  type        = bool
+  default     = true
+}
+
 variable "project_id" {
   description = "GCP project ID."
   type        = string
@@ -72,24 +137,6 @@ variable "create_workload_identity_pool" {
   description = "When true, create Workload Identity Pool + OIDC Provider using the effective CKS OIDC issuer URL."
   type        = bool
   default     = true
-}
-
-variable "cks_oidc_issuer_url" {
-  description = "Optional explicit CKS OIDC issuer URL. If unset, this can be sourced from cks_remote_state outputs."
-  type        = string
-  default     = null
-}
-
-variable "cks_remote_state_backend" {
-  description = "Optional terraform_remote_state backend for reading CKS outputs (for example: local, s3, gcs, remote)."
-  type        = string
-  default     = null
-}
-
-variable "cks_remote_state_config" {
-  description = "Optional terraform_remote_state backend config map used when cks_remote_state_backend is set."
-  type        = map(string)
-  default     = {}
 }
 
 variable "wif_subject" {

--- a/secrets-management/cloud-kms/gcp-kms/terraform/versions.tf
+++ b/secrets-management/cloud-kms/gcp-kms/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/secrets-management/cloud-kms/gcp-kms/terraform/versions.tf
+++ b/secrets-management/cloud-kms/gcp-kms/terraform/versions.tf
@@ -10,5 +10,13 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 6.0"
     }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 6.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.11"
+    }
   }
 }

--- a/secrets-management/cloud-kms/gcp-kms/terraform/versions.tf
+++ b/secrets-management/cloud-kms/gcp-kms/terraform/versions.tf
@@ -2,6 +2,10 @@ terraform {
   required_version = ">= 1.5.0"
 
   required_providers {
+    coreweave = {
+      source  = "coreweave/coreweave"
+      version = ">= 0.3.0"
+    }
     google = {
       source  = "hashicorp/google"
       version = "~> 6.0"


### PR DESCRIPTION
## Summary
- Add cloud-kms reference docs under `secrets-management/`.
- Add AWS reference: AWS KMS + Secrets Manager + ESO manifests + Terraform.
- Add GCP reference: Cloud KMS (CMEK) + Secret Manager + ESO manifests + Terraform.
- Each example provisions its own CoreWeave VPC and CKS cluster, then wires federation directly from `module.cks.service_account_oidc_issuer_url` — no `terraform_remote_state` dependency.
- Optional automation for AWS IAM OIDC provider creation (`create_oidc_provider`) and GCP Workload Identity Pool/provider creation (`create_workload_identity_pool`).
- AWS ServiceAccount carries the `eks.amazonaws.com/role-arn` annotation for ESO IRSA; SecretStore omits the redundant `role` field.
- Each example ships an `manifests/cpu-nodepool.yaml` starter for clusters without auto-allocated capacity.

## Validation
- `terraform fmt` passes for both Terraform dirs.
- AWS example exercised end-to-end on CKS: Terraform apply → ESO install → ExternalSecret syncs three keys → demo app reads them → rotation via `aws secretsmanager put-secret-value` propagates within one refresh interval → IAM scope negative test returns `AccessDenied` on an out-of-scope secret → `terraform destroy` cleans up.
- GCP example mirrors the AWS structural fixes but is not yet runtime-tested.