### PR TITLE
feat(secrets-management): add external-secrets operator reference architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # reference-architecture
 Reference architectures for various use cases at CoreWeave.
+
+## Additional Reference Areas
+
+- [secrets-management](./secrets-management/README.md): External Secrets Operator baseline and secrets-management patterns for Kubernetes workloads.

--- a/secrets-management/README.md
+++ b/secrets-management/README.md
@@ -1,0 +1,29 @@
+# Secrets Management Reference Architectures
+
+This directory contains end-to-end reference architectures for managing application secrets on CoreWeave Kubernetes Service (CKS).
+
+## Architectures
+
+| Architecture | Backend | Auth Model | Path |
+| --- | --- | --- | --- |
+| ESO | External Secrets Operator control plane baseline | Shared Kubernetes operator, controller-class scoped | [`eso/`](./eso/README.md) |
+
+## Shared Prerequisites
+
+- A running CKS cluster.
+- `kubectl` and `helm` installed and configured.
+
+## Validation Pattern
+
+1. Deploy the reference architecture.
+2. Confirm operator health:
+
+```bash
+kubectl get pods -n external-secrets
+```
+
+3. Confirm ESO CRDs are present:
+
+```bash
+kubectl get crd | rg external-secrets.io
+```

--- a/secrets-management/eso/README.md
+++ b/secrets-management/eso/README.md
@@ -1,0 +1,54 @@
+# External Secrets Operator (ESO) Reference Architecture
+
+This reference defines a reusable ESO baseline for CKS clusters that consume external secret backends (Infisical, AWS Secrets Manager, GCP Secret Manager, and others).
+
+## Architecture
+
+1. ESO runs as a shared platform component in the `external-secrets` namespace.
+2. A dedicated controller class (`platform-secrets`) is used to scope managed `SecretStore`/`ClusterSecretStore` resources.
+3. Application namespaces define `ExternalSecret` resources that sync provider values into Kubernetes `Secret` objects.
+4. Provider-specific store configuration is handled by each backend architecture guide under `secrets-management/`.
+
+## Why This Exists
+
+The Infisical and Cloud KMS guides depend on a working ESO control plane. This reference makes that prerequisite explicit and repeatable.
+
+## Deploy
+
+1. Create namespace and baseline labels:
+
+```bash
+kubectl apply -f manifests/00-namespace.yaml
+```
+
+2. Install ESO with the reference values:
+
+```bash
+helm repo add external-secrets https://charts.external-secrets.io
+helm repo update
+helm upgrade --install external-secrets external-secrets/external-secrets \
+  --namespace external-secrets \
+  --create-namespace \
+  -f helm-values.yaml
+```
+
+3. Verify controller health and CRDs:
+
+```bash
+kubectl get pods -n external-secrets
+kubectl get crd | rg external-secrets.io
+```
+
+## Controller Class Usage
+
+This reference sets:
+
+```yaml
+controllerClass: platform-secrets
+```
+
+To ensure the controller picks up intended stores, set `spec.controller: platform-secrets` on each `SecretStore` or `ClusterSecretStore`.
+
+## Next Steps
+
+Add provider-specific `SecretStore`/`ExternalSecret` references for your selected backend (for example Infisical, AWS Secrets Manager, or GCP Secret Manager) using this ESO baseline.

--- a/secrets-management/eso/helm-values.yaml
+++ b/secrets-management/eso/helm-values.yaml
@@ -1,0 +1,11 @@
+installCRDs: true
+
+# Run controller components with >1 replica for better availability.
+replicaCount: 2
+controllerClass: platform-secrets
+
+webhook:
+  replicaCount: 2
+
+certController:
+  replicaCount: 2

--- a/secrets-management/eso/manifests/00-namespace.yaml
+++ b/secrets-management/eso/manifests/00-namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-secrets
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted


### PR DESCRIPTION
## Summary
- add a dedicated ESO reference architecture under secrets-management/eso
- add operator baseline artifacts: namespace manifest and Helm values
- update secrets-management docs to use the ESO guide as the shared prerequisite

## Validation
- documentation and manifest additions are committed
- runtime validation requires cluster access and ESO chart installation