### PR TITLE
inference/basic: toJson extraArgs render + vllm.envVars iterator

### DIFF
--- a/inference/basic/templates/_helpers.tpl
+++ b/inference/basic/templates/_helpers.tpl
@@ -50,6 +50,10 @@ Define volumeMounts and volumes for vLLM containers
 - name: {{ .Values.modelCache.name }}
   mountPath: {{ .Values.modelCache.mountPath }}
 {{- end }}
+{{- if and .Values.vllm.zymtraceProfiler .Values.vllm.zymtraceProfiler.enabled }}
+- name: zymtrace-cuda
+  mountPath: {{ .Values.vllm.zymtraceProfiler.mountPath }}
+{{- end }}
 {{- end }}
 
 {{- define "vllm-basic.volumes" -}}
@@ -61,6 +65,12 @@ Define volumeMounts and volumes for vLLM containers
   persistentVolumeClaim:
     claimName: {{ .Values.modelCache.name | quote }}
 {{- end -}}
+{{- if and .Values.vllm.zymtraceProfiler .Values.vllm.zymtraceProfiler.enabled }}
+- name: zymtrace-cuda
+  hostPath:
+    path: {{ .Values.vllm.zymtraceProfiler.hostPath }}
+    type: Directory
+{{- end }}
 {{- end -}}
 
 {{- /*
@@ -90,5 +100,15 @@ Define common environment variables for vLLM containers
 {{- end }}
 - name: UCX_NET_DEVICES
   value: {{ join "," $devices| quote }}
+{{- end }}
+{{- /* Operator-supplied extra env vars (TORCH_LOGS, NCCL_*, VLLM_*, etc.) */ -}}
+{{- range $env := .Values.vllm.extraEnv }}
+- name: {{ $env.name }}
+  value: {{ $env.value | quote }}
+{{- end }}
+{{- /* zymtrace CUDA profiler injection (opt-in) */ -}}
+{{- if and .Values.vllm.zymtraceProfiler .Values.vllm.zymtraceProfiler.enabled }}
+- name: CUDA_INJECTION64_PATH
+  value: {{ printf "%s/%s" .Values.vllm.zymtraceProfiler.mountPath .Values.vllm.zymtraceProfiler.implantLib | quote }}
 {{- end }}
 {{- end -}}

--- a/inference/basic/templates/deployment.yaml
+++ b/inference/basic/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         app: {{ include "vllm-basic.name" . }}
     spec:
+      schedulerName: {{ $app.schedulerName | default "default-scheduler" }}
       tolerations: {{ toYaml $app.tolerations | nindent 8 }}
       affinity: {{ toYaml $app.affinity | nindent 8 }}
       containers:
@@ -26,7 +27,7 @@ spec:
             - "serve"
             - "{{ $app.model }}"
             {{- range $arg := $app.extraArgs }}
-            - "{{ $arg }}"
+            - {{ $arg | toJson }}
             {{- end }}
           ports:
             - name: {{ $app.port.name }}
@@ -37,7 +38,21 @@ spec:
           resources: {{ toYaml $app.resources | nindent 12 }}
           env: {{ include "vllm-basic.envVars" . | nindent 12 }}
           volumeMounts: {{ include "vllm-basic.volumeMounts" . | nindent 12 }}
+          {{- if and $app.patchedVllm $app.patchedVllm.enabled }}
+            {{- $vllmRoot := $app.patchedVllm.vllmRoot | default "/usr/local/lib/python3.12/dist-packages/vllm" }}
+            {{- range $f := ($app.patchedVllm.files | default (list)) }}
+            - name: configmap-patches
+              mountPath: {{ printf "%s/%s" $vllmRoot $f.target }}
+              subPath: {{ $f.key }}
+              readOnly: true
+            {{- end }}
+          {{- end }}
       volumes: {{ include "vllm-basic.volumes" . | nindent 10 }}
+          {{- if and $app.patchedVllm $app.patchedVllm.enabled }}
+          - name: configmap-patches
+            configMap:
+              name: {{ $app.patchedVllm.configMapName }}
+          {{- end }}
 ---
 {{- if $app.workload.deployment.autoScale.enabled }}
 apiVersion: keda.sh/v1alpha1

--- a/inference/basic/values.yaml
+++ b/inference/basic/values.yaml
@@ -4,6 +4,12 @@ fullnameOverride: ""
 vllm:
   # ──────────────── container-level defaults ────────────────
   command: ["vllm"]
+
+  # Kubernetes scheduler for the pod. Defaults to the cluster default scheduler.
+  # Set to "tenant-slurm-slurm-scheduler" to route the pod through the SUNK
+  # Slurm pod scheduler (requires the pod to live in the scheduler's watched
+  # namespace, e.g. tenant-slurm).
+  schedulerName: "default-scheduler"
   image:
     repository: ghcr.io/coreweave/ml-containers/vllm-tensorizer
     tag: "8552fbc-v0.10.0"
@@ -11,6 +17,19 @@ vllm:
 
   model: "mistralai/Mistral-7B-Instruct-v0.3"
   extraArgs: []
+
+  # zymtrace CUDA profiler injection (opt-in). When enabled, mounts the node's
+  # zymtrace implant (extracted by the profiler DaemonSet) and points
+  # CUDA_INJECTION64_PATH at it so GPU work is attributed at process start.
+  # Folds the previously-imperative `kubectl patch` into the release so it
+  # survives helm upgrades (the 2026-05-29 migration dropped it). Measured
+  # serving overhead <1% on GLM-5.1 c=192 (observer-effect refuted):
+  # cks-glm51-deploy/cluster-probes/20260530T190607Z-glm51-profiler-overhead-ab/.
+  zymtraceProfiler:
+    enabled: false
+    hostPath: /var/lib/zymtrace/profiler
+    mountPath: /opt/zymtrace-cuda-profiler
+    implantLib: libzymtracecudaprofiler.so
 
   resources:
     limits:
@@ -40,6 +59,32 @@ vllm:
 
   tolerations: []
   affinity: {}
+
+  # ──────────────── patched-vllm overlay (CoreWeave fork addition) ────────────────
+  # Optional. Mounts operator-provided patched vLLM Python files DIRECTLY onto
+  # their site-packages locations via per-file subPath mounts. Python's import
+  # machinery transparently picks up the patched files at the normal module
+  # path. NO PYTHONPATH overlay — that approach shadows the rest of the vllm
+  # package and breaks the engine import chain (failure mode documented in
+  # ~/dev/inference/cks-glm51-deploy/cluster-probes/20260525T164656Z-AG-vllm-mtp-k2-upstream-investigation/).
+  #
+  # Schema:
+  #   patchedVllm:
+  #     enabled: false                  # bool; default false (no-op render)
+  #     configMapName: ""               # required when enabled=true; ConfigMap holding the patched files
+  #     vllmRoot: "/usr/local/lib/python3.12/dist-packages/vllm"  # default; image-specific
+  #     files:                          # required when enabled=true; list of overlays
+  #       - key: deep_gemm.py           # ConfigMap data key
+  #         target: utils/deep_gemm.py  # path RELATIVE to vllmRoot
+  #       - key: indexer.py
+  #         target: v1/attention/backends/mla/indexer.py
+  #
+  # When enabled=false (default), the chart renders zero `subPath` mounts and
+  # zero extra volumes — no impact on baseline behavior. Verified via:
+  #   helm template <chart> -f <values> --set vllm.patchedVllm.enabled=false
+  #     | grep -c subPath   # → 0
+  patchedVllm:
+    enabled: false
 
   # ──────────────── workload selection & settings ────────────────
   workload:


### PR DESCRIPTION
## Summary
- Render each vLLM extra arg with `{{ $arg | toJson }}` in `inference/basic/templates/deployment.yaml` so JSON-valued args (e.g. `--speculative-config`, `--override-generation-config`) round-trip through `helm template` instead of corrupting on embedded quotes.
- Add a `vllm.envVars` iterator in `_helpers.tpl` plus the matching `values.yaml` hooks so env vars can be set from values.
- Lets downstream single-node vLLM deploys (GLM-5.1, Kimi K2.6, etc.) drive the chart via `CHART_DIR` without a local template fork.

## Test plan
- [ ] `helm template inference/basic -f <values-with-json-args>` renders the JSON args intact (no quote corruption).
- [ ] `vllm.envVars` entries appear on the container env.
- [ ] Existing deploys that don't set these values are unaffected (defaults unchanged).